### PR TITLE
Temporarily ignore runtime warning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ changedir =
     tests
 
 commands =
-    py.test []
+    py.test -W ignore []
 
 deps =
     pytest


### PR DESCRIPTION
Lots of runtime warning in test cases currently, will fully adapt python 3.x later.