### PR TITLE
Use array.tobytes() on python3

### DIFF
--- a/thriftpy/protocol/compact.py
+++ b/thriftpy/protocol/compact.py
@@ -58,12 +58,12 @@ def write_varint(trans, n):
         else:
             out.append((n & 0xff) | 0x80)
             n = n >> 7
-    data = array.array('B', out).tostring()
+    data = array.array('B', out)
 
     if PY3:
-        trans.write(data)
+        trans.write(data.tobytes())
     else:
-        trans.write(bytes(data))
+        trans.write(bytes(data.tostring()))
 
 
 def read_varint(trans):

--- a/thriftpy/protocol/compact.py
+++ b/thriftpy/protocol/compact.py
@@ -63,7 +63,7 @@ def write_varint(trans, n):
     if PY3:
         trans.write(data.tobytes())
     else:
-        trans.write(bytes(data.tostring()))
+        trans.write(data.tostring())
 
 
 def read_varint(trans):


### PR DESCRIPTION
This can silence most of the deprecation warning.