### PR TITLE
Fix unpickle obj attribute error

### DIFF
--- a/thriftpy2/protocol/binary.py
+++ b/thriftpy2/protocol/binary.py
@@ -151,7 +151,7 @@ def write_val(outbuf, ttype, val, spec=None):
             else:
                 f_type, f_name, f_container_spec, f_req = f_spec
 
-            v = getattr(val, f_name)
+            v = getattr(val, f_name, None)
             if v is None:
                 continue
 

--- a/thriftpy2/protocol/compact.py
+++ b/thriftpy2/protocol/compact.py
@@ -442,7 +442,7 @@ class TCompactProtocol(object):
                 f_container_spec = None
             else:
                 ftype, fname, f_container_spec, f_req = fspec
-            val = getattr(obj, fname)
+            val = getattr(obj, fname, None)
             if val is None:
                 continue
 

--- a/thriftpy2/protocol/cybin/cybin.pyx
+++ b/thriftpy2/protocol/cybin/cybin.pyx
@@ -202,7 +202,7 @@ cdef inline write_struct(CyTransportBase buf, obj):
         else:
             container_spec = field_spec[2]
 
-        v = getattr(obj, f_name)
+        v = getattr(obj, f_name, None)
         if v is None:
             continue
 


### PR DESCRIPTION
https://paste.ubuntu.com/25721297/
raise AttributeError when unpickle object get attribute
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-b4fa9c6bca01> in <module>()
----> 1 getattr(hongbao, 'detail_json')

AttributeError: 'THongbao' object has no attribute 'detail_json'
```