### PR TITLE
Add i8 as alias for 'byte'

### DIFF
--- a/tests/parser-cases/constants.thrift
+++ b/tests/parser-cases/constants.thrift
@@ -1,5 +1,7 @@
 const bool tbool = true
 const bool tboolint = 1
+const byte tbyte = 3
+const i8 int8 = 3
 const i16 int16 = 3
 const i32 int32 = 800
 const i64 int64 = 123456789

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -14,6 +14,8 @@ def test_constants():
     thrift = load('parser-cases/constants.thrift')
     assert thrift.tbool is True
     assert thrift.tboolint is True
+    assert thrift.tbyte == 3
+    assert thrift.int8 == 3
     assert thrift.int16 == 3
     assert thrift.int32 == 800
     assert thrift.int64 == 123456789

--- a/thriftpy2/parser/lexer.py
+++ b/thriftpy2/parser/lexer.py
@@ -123,6 +123,7 @@ keywords = (
     'void',
     'bool',
     'byte',
+    'i8',
     'i16',
     'i32',
     'i64',

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -409,6 +409,7 @@ def p_ref_type(p):
 def p_simple_base_type(p):  # noqa
     '''simple_base_type : BOOL
                         | BYTE
+                        | I8
                         | I16
                         | I32
                         | I64
@@ -417,7 +418,7 @@ def p_simple_base_type(p):  # noqa
                         | BINARY'''
     if p[1] == 'bool':
         p[0] = TType.BOOL
-    if p[1] == 'byte':
+    if p[1] == 'byte' or p[1] == 'i8':
         p[0] = TType.BYTE
     if p[1] == 'i16':
         p[0] = TType.I16


### PR DESCRIPTION
[THRIFT-3393](https://jira.apache.org/jira/browse/THRIFT-3393) added i8 as an alias for byte, for consistency with the other integer types.