### PR TITLE
 Fix #41

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ pip-log.txt
 *.sublime-workspace
 *.sw[op]
 env/
+.vscode/

--- a/tests/container.thrift
+++ b/tests/container.thrift
@@ -1,3 +1,7 @@
+struct ListStruct {
+    1: optional list<ListItem> list_items,
+}
+
 struct ListItem {
     1: optional list<string> list_string,
     2: optional list<list<string>> list_list_string,
@@ -11,9 +15,4 @@ struct MapItem {
 struct MixItem {
     1: optional list<map<string, string>> list_map,
     2: optional map<string, list<string>> map_list,
-}
-
-
-struct ListStruct {
-    1: optional list<ListItem> list_items,
 }

--- a/thriftpy2/parser/__init__.py
+++ b/thriftpy2/parser/__init__.py
@@ -93,8 +93,11 @@ def fill_incomplete_ttype(tmodule, definition):
                 definition.thrift_spec[index] = (
                     value[0],
                     value[1],
-                    get_definition(
-                            tmodule, *incomplete_type[value[2]]),
+                    fill_incomplete_ttype(
+                        tmodule, get_definition(
+                            tmodule, *incomplete_type[value[2]]
+                        )
+                    ),
                     value[3])
     # handle service method
     elif hasattr(definition, "thrift_services"):

--- a/thriftpy2/parser/__init__.py
+++ b/thriftpy2/parser/__init__.py
@@ -43,7 +43,8 @@ def fill_incomplete_ttype(tmodule, definition):
     if isinstance(definition, tuple):
         # fill const value
         if definition[0] == 'UNKNOWN_CONST':
-            ttype = get_definition(tmodule, incomplete_type[definition[1]][0], definition[3])
+            ttype = get_definition(
+                tmodule, incomplete_type[definition[1]][0], definition[3])
             return _cast(ttype)(definition[2])
         # fill an incomplete alias ttype
         if definition[1] in incomplete_type:
@@ -61,7 +62,7 @@ def fill_incomplete_ttype(tmodule, definition):
         for name, attr in definition.__dict__.items():
             if name.startswith('__'):  # skip inner attribute
                 continue
-            setattr(definition, name, fill_incomplete_ttype(tmodule, attr))
+            setattr(definition, name, fill_incomplete_ttype(definition, attr))
     # handle struct ttype
     elif isinstance(definition, TPayloadMeta):
         for index, value in definition.thrift_spec.items():
@@ -88,11 +89,12 @@ def fill_incomplete_ttype(tmodule, definition):
                         ),
                     ) + tuple(value[1:])
             # if the ttype which field's ttype contains is incomplete
-            elif isinstance(value[2], tuple):
+            elif value[2] in incomplete_type:
                 definition.thrift_spec[index] = (
                     value[0],
                     value[1],
-                    fill_incomplete_ttype(tmodule, value[2]),
+                    get_definition(
+                            tmodule, *incomplete_type[value[2]]),
                     value[3])
     # handle service method
     elif hasattr(definition, "thrift_services"):


### PR DESCRIPTION
Fix #41: can not process compound types in struct definition when the IDL is out of order, and other bugs:
- Unnecessary processing already complete type in out-of-order handler.
- Can not process out-of-order definitions in submodules with `include`.