### PR TITLE
Add default timeout for make_client

### DIFF
--- a/thriftpy2/rpc.py
+++ b/thriftpy2/rpc.py
@@ -22,7 +22,7 @@ from thriftpy2.transport import (
 def make_client(service, host="localhost", port=9090, unix_socket=None,
                 proto_factory=TBinaryProtocolFactory(),
                 trans_factory=TBufferedTransportFactory(),
-                timeout=None,
+                timeout=3000,
                 cafile=None, ssl_context=None, certfile=None, keyfile=None):
     if unix_socket:
         socket = TSocket(unix_socket=unix_socket)


### PR DESCRIPTION
I think it's necessary for having a default timeout for `make_client`, and the `make_server` / `make_aio_server` / `make_aio_client` have the default timeout already.