### PR TITLE
Fixes #61 parse error on empty set field value

### DIFF
--- a/tests/parser-cases/structs.thrift
+++ b/tests/parser-cases/structs.thrift
@@ -3,14 +3,21 @@ struct Person {
     2: string address
 }
 
+struct MetaData {
+    1: set<string> tags = {}
+}
+
 struct Email {
     1: string subject = 'Subject',
     2: string content,
     3: Person sender,
     4: required Person recver,
+    5: MetaData metadata
 }
+
 
 const Email email = {'subject': 'Hello', 'content': 'Long time no see',
     'sender': {'name': 'jack', 'address': 'jack@gmail.com'},
-    'recver': {'name': 'chao', 'address': 'chao@gmail.com'}
+    'recver': {'name': 'chao', 'address': 'chao@gmail.com'},
+    'metadata': {},
 }

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -124,21 +124,26 @@ def test_structs():
     assert thrift.Person.default_spec == [
         ('name', None), ('address', None)
     ]
+    assert thrift.MetaData.thrift_spec == {
+        1: (TType.SET, 'tags', TType.STRING, False)
+    }
     assert thrift.Email.thrift_spec == {
         1: (TType.STRING, 'subject', False),
         2: (TType.STRING, 'content', False),
         3: (TType.STRUCT, 'sender', thrift.Person, False),
         4: (TType.STRUCT, 'recver', thrift.Person, True),
+        5: (TType.STRUCT, 'metadata', thrift.MetaData, False),
     }
     assert thrift.Email.default_spec == [
         ('subject', 'Subject'), ('content', None),
-        ('sender', None), ('recver', None)
+        ('sender', None), ('recver', None), ('metadata', None)
     ]
     assert thrift.email == thrift.Email(
         subject='Hello',
         content='Long time no see',
         sender=thrift.Person(name='jack', address='jack@gmail.com'),
-        recver=thrift.Person(name='chao', address='chao@gmail.com')
+        recver=thrift.Person(name='chao', address='chao@gmail.com'),
+        metadata=thrift.MetaData(tags=set())
     )
 
 

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -748,6 +748,8 @@ def _cast_set(t):
     assert t[0] == TType.SET
 
     def __cast_set(v):
+        if len(v) == 0 and isinstance(v, dict):
+            v = set()
         assert isinstance(v, (list, set))
         map(_cast(t[1]), v)
         if not isinstance(v, set):


### PR DESCRIPTION
 * Added a check in the parser to convert lines with empty set constants.
 * To test this followed the example of the email struct and added a metadata struct
  to the email which holdes an empty set of strings. Seemed like the most logical way
  to include parser bug in the existing tests.