### PR TITLE
Use readall() in TAsyncSocket to ensure all data is received

### DIFF
--- a/thriftpy2/contrib/aio/socket.py
+++ b/thriftpy2/contrib/aio/socket.py
@@ -18,6 +18,22 @@ from thriftpy2.transport._ssl import (
 )
 
 
+@asyncio.coroutine
+def readall(read_fn, sz):
+    buff = b''
+    have = 0
+    while have < sz:
+        chunk = yield from read_fn(sz - have)
+        have += len(chunk)
+        buff += chunk
+
+        if len(chunk) == 0:
+            raise TTransportException(TTransportException.END_OF_FILE,
+                                      "End of file reading from transport")
+
+    return buff
+
+
 class TAsyncSocket(object):
     """Socket implementation for client side."""
 
@@ -164,7 +180,7 @@ class TAsyncSocket(object):
                 message="Could not connect to %s" % str(addr))
 
     @asyncio.coroutine
-    def read(self, sz):
+    def _read(self, sz):
         try:
             buff = yield from asyncio.wait_for(
                 self.reader.read(sz),
@@ -188,6 +204,10 @@ class TAsyncSocket(object):
             raise TTransportException(type=TTransportException.END_OF_FILE,
                                       message='TSocket read 0 bytes')
         return buff
+
+    @asyncio.coroutine
+    def read(self, sz):
+        return (yield from readall(self._read, sz))
 
     def write(self, buff):
         self.writer.write(buff)

--- a/thriftpy2/contrib/aio/transport/buffered.py
+++ b/thriftpy2/contrib/aio/transport/buffered.py
@@ -36,7 +36,7 @@ class TAsyncBufferedTransport(TTransportBase):
         if len(ret) != 0:
             return ret
 
-        buf = yield from self._trans.read(max(sz, self._buf_size))
+        buf = yield from self._trans.read(min(sz, self._buf_size))
         self._rbuf = BytesIO(buf)
         return self._rbuf.read(sz)
 

--- a/thriftpy2/contrib/aio/transport/buffered.py
+++ b/thriftpy2/contrib/aio/transport/buffered.py
@@ -2,23 +2,8 @@
 import asyncio
 from io import BytesIO
 
-from thriftpy2.transport import TTransportBase, TTransportException
-
-
-@asyncio.coroutine
-def readall(read_fn, sz):
-    buff = b''
-    have = 0
-    while have < sz:
-        chunk = yield from read_fn(sz - have)
-        have += len(chunk)
-        buff += chunk
-
-        if len(chunk) == 0:
-            raise TTransportException(TTransportException.END_OF_FILE,
-                                      "End of file reading from transport")
-
-    return buff
+from thriftpy2.transport import TTransportBase
+from ..socket import readall
 
 
 class TAsyncBufferedTransport(TTransportBase):


### PR DESCRIPTION
While accessing HBase via asyncio, I found that my test cases would randomly fail.  It turned out that not all of the data was being consumed by `TAsyncSocket.read()`, so I refactored it to use the `readall()` that `TAsyncBufferedTransport` uses.

I moved `readall()` into socket.py because it made sense to put it with the lower level implementation.