### PR TITLE
Fix async read size bugs

### DIFF
--- a/thriftpy2/contrib/aio/socket.py
+++ b/thriftpy2/contrib/aio/socket.py
@@ -183,9 +183,13 @@ class TAsyncSocket(object):
                 # in lib/cpp/src/transport/TSocket.cpp.
                 self.close()
                 # Trigger the check to raise the END_OF_FILE exception below.
-                buff = ''
+                buff = b''
             else:
                 raise
+        except asyncio.IncompleteReadError:
+            self.close()
+            # Trigger the check to raise the END_OF_FILE exception below.
+            buff = b''
 
         if len(buff) == 0:
             raise TTransportException(type=TTransportException.END_OF_FILE,

--- a/thriftpy2/contrib/aio/socket.py
+++ b/thriftpy2/contrib/aio/socket.py
@@ -165,9 +165,12 @@ class TAsyncSocket(object):
 
     @asyncio.coroutine
     def read(self, sz):
+        if sz == 0:  # Special case
+            return b''
+
         try:
             buff = yield from asyncio.wait_for(
-                self.reader.read(sz),
+                self.reader.readexactly(sz),
                 self.connect_timeout
             )
         except socket.error as e:

--- a/thriftpy2/contrib/aio/transport/buffered.py
+++ b/thriftpy2/contrib/aio/transport/buffered.py
@@ -51,7 +51,7 @@ class TAsyncBufferedTransport(TTransportBase):
         if len(ret) != 0:
             return ret
 
-        buf = yield from self._trans.read(max(sz, self._buf_size))
+        buf = yield from self._trans.read(min(sz, self._buf_size))
         self._rbuf = BytesIO(buf)
         return self._rbuf.read(sz)
 


### PR DESCRIPTION
- Make sure TAsyncSocket reads all of the data
- Ask for the min size, not the max in TAsyncBufferedTransport.read()