### PR TITLE
contrib.aio.processor: Fix missing asyncio.coroutine decorator

### DIFF
--- a/thriftpy2/contrib/aio/processor.py
+++ b/thriftpy2/contrib/aio/processor.py
@@ -58,6 +58,7 @@ class TAsyncProcessor(object):
         else:
             raise
 
+    @asyncio.coroutine
     def process(self, iprot, oprot):
         api, seqid, result, call = yield from self.process_in(iprot)
 


### PR DESCRIPTION
This PR fixes an error `TypeError: object generator can't be used in 'await' expression` when I call thriftpy2 on latest Python 3.8 with native async functions.