### PR TITLE
Include tests in the sdist tarball on pypi

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include README.rst CHANGES.rst LICENSE
 recursive-include thriftpy2/protocol/cybin *.pyx *.c *.h
 recursive-include thriftpy2/transport *.pyx *.pxd *.c
 include thriftpy2/contrib/tracking/tracking.thrift
+recursive-include tests/ *


### PR DESCRIPTION
If a vendor wants to validate the thriftpy2 against his python stack this allows him to use the pypi archive instead of relying on github tags.