### PR TITLE
Support include files with dot in name

### DIFF
--- a/tests/parser-cases/issue_121.include.thrift
+++ b/tests/parser-cases/issue_121.include.thrift
@@ -1,0 +1,3 @@
+struct A {
+    1: string value
+}

--- a/tests/parser-cases/issue_121.thrift
+++ b/tests/parser-cases/issue_121.thrift
@@ -1,0 +1,5 @@
+include "./issue_121.include.thrift"
+
+struct B {
+    1: issue_121.include.A a
+}

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -13,7 +13,7 @@ import thriftpy2
 thriftpy2.install_import_hook()  # noqa
 
 from thriftpy2.http import make_server, make_client, client_context  # noqa
-from thriftpy2.thrift import TApplicationException
+from thriftpy2.thrift import TApplicationException  # noqa
 
 
 addressbook = thriftpy2.load(os.path.join(os.path.dirname(__file__),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -298,3 +298,7 @@ def test_nest_incomplete_type():
         2: (15, 'field2', (15, (12, thrift.A)), False),
         3: (15, 'field3', (15, (15, (12, thrift.A))), False)
     }
+
+
+def test_issue_121():
+    load('parser-cases/issue_121.thrift')


### PR DESCRIPTION
Not a completed work, for now just support "one level include", like including a file called "com.example.api.thrift".

On the opposite, including a file called "com.example.thrift", which also including another file "api.thrift", is not supported now.

So this PR is marked as WIP, I'll try to finish this latter.

Close #121 