### PR TITLE
Support Cython in HTTP and fix TCyBufferedTransport early flush issue

### DIFF
--- a/thriftpy2/http.py
+++ b/thriftpy2/http.py
@@ -217,13 +217,16 @@ class THttpClient(object):
         self.__wbuf.write(buf)
 
     def flush(self):
+        # Pull data out of buffer
+        # Do this before opening a new connection in case there isn't data
+        data = self.__wbuf.getvalue()
+        self.__wbuf = BytesIO()
+        if not data:  # No data to flush, ignore
+            return
+
         if self.isOpen():
             self.close()
         self.open()
-
-        # Pull data out of buffer
-        data = self.__wbuf.getvalue()
-        self.__wbuf = BytesIO()
 
         # HTTP request
         self.__http.putrequest('POST', self.path, skip_host=True)

--- a/thriftpy2/http.py
+++ b/thriftpy2/http.py
@@ -54,23 +54,10 @@ else:
 
 from thriftpy2.thrift import TProcessor, TClient
 from thriftpy2.server import TServer
-from thriftpy2.transport import (
-    TTransportBase,
-    TMemoryBuffer
-)
-# Explicitly use Python version instead of Cython version for libraries below
-# to address some mystery issues for now.
-#
-# Avoid TypeError: Cannot convert TBufferedTransport to
-# thriftpy2.transport.cybase.CyTransportBase.
-from thriftpy2.protocol.binary import TBinaryProtocolFactory
-# Avoid raised error of too small buffer allocated by TCyBufferedTransport.
-# Also, using TCyBufferedTransportFactory will let THttpClient write a broken
-# string to server, which making server freezed in transport.readall() method.
-from thriftpy2.transport.buffered import (
-    TBufferedTransport,
-    TBufferedTransportFactory,
-)
+from thriftpy2.transport import TTransportBase, TMemoryBuffer
+
+from thriftpy2.protocol import TBinaryProtocolFactory
+from thriftpy2.transport import TBufferedTransportFactory
 
 
 HTTP_URI = '{scheme}://{host}:{port}{path}'
@@ -120,6 +107,7 @@ class THttpServer(TServer):
     def __init__(self,
                  processor,
                  server_address,
+                 itrans_factory,
                  iprot_factory,
                  server_class=http_server.HTTPServer):
         """Set up protocol factories and HTTP server.
@@ -127,7 +115,8 @@ class THttpServer(TServer):
         See TServer for protocol factories.
         """
         TServer.__init__(self, processor, trans=None,
-                         itrans_factory=None, iprot_factory=iprot_factory,
+                         itrans_factory=itrans_factory,
+                         iprot_factory=iprot_factory,
                          otrans_factory=None, oprot_factory=None)
 
         thttpserver = self
@@ -137,12 +126,18 @@ class THttpServer(TServer):
 
             def do_POST(self):
                 # Don't care about the request path.
-                itrans = TFileObjectTransport(self.rfile)
-                otrans = TFileObjectTransport(self.wfile)
-                itrans = TBufferedTransport(
-                    itrans, int(self.headers['Content-Length']))
-                otrans = TMemoryBuffer()
+                # Pre-read all of the data into a BytesIO. Buffered transport
+                # was previously configured to read everything on the first
+                # consumption, but that was a hack relying on the internal
+                # mechanism and prevents other transports from working, so
+                # replicate that properly to prevent timeout issues
+                content_len = int(self.headers['Content-Length'])
+                buf = BytesIO(self.rfile.read(content_len))
+                itrans = TFileObjectTransport(buf)
+                itrans = thttpserver.itrans_factory.get_transport(itrans)
                 iprot = thttpserver.iprot_factory.get_protocol(itrans)
+
+                otrans = TMemoryBuffer()
                 oprot = thttpserver.oprot_factory.get_protocol(otrans)
                 try:
                     thttpserver.processor.process(iprot, oprot)
@@ -323,8 +318,10 @@ def client_context(service, host='localhost', port=9090, path='', scheme='http',
 
 
 def make_server(service, handler, host, port,
-                proto_factory=TBinaryProtocolFactory()):
+                proto_factory=TBinaryProtocolFactory(),
+                trans_factory=TBufferedTransportFactory()):
     processor = TProcessor(service, handler)
     server = THttpServer(processor, (host, port),
+                         itrans_factory=trans_factory,
                          iprot_factory=proto_factory)
     return server

--- a/thriftpy2/protocol/cybin/cybin.pyx
+++ b/thriftpy2/protocol/cybin/cybin.pyx
@@ -460,7 +460,7 @@ cdef class TCyBinaryProtocol(object):
         write_i32(self.trans, seqid)
 
     def write_message_end(self):
-        self.trans.c_flush()
+        pass
 
     def read_struct(self, obj):
         try:

--- a/thriftpy2/transport/buffered/cybuffered.pyx
+++ b/thriftpy2/transport/buffered/cybuffered.pyx
@@ -52,7 +52,7 @@ cdef class TCyBufferedTransport(CyTransportBase):
             int r
 
         if cap < sz:
-            self.c_flush()
+            self.c_dump_wbuf()
 
         r = self.wbuf.write(sz, data)
         if r == -1:
@@ -74,11 +74,14 @@ cdef class TCyBufferedTransport(CyTransportBase):
             raise MemoryError("grow read buffer fail")
 
     cdef c_flush(self):
+        self.c_dump_wbuf()
+        self.trans.flush()
+
+    cdef c_dump_wbuf(self):
         cdef bytes data
         if self.wbuf.data_size > 0:
             data = self.wbuf.buf[:self.wbuf.data_size]
             self.trans.write(data)
-            self.trans.flush()
             self.wbuf.clean()
 
     def getvalue(self):


### PR DESCRIPTION
**TL;DR**
This PR solves two issues:
- TCyBufferedTransport flusing the underlying transport before the message is complete
- HTTP client only supporting pure Python TBufferedTransport

-----

While developing an alternative HTTP client to the one in thriftpy2.http using HTTPX (so I can use the same GSSAPI authentication on both sync and async) I ran into the issue [described here:](https://github.com/Thriftpy/thriftpy2/blob/master/thriftpy2/http.py#L68)

>  Also, using TCyBufferedTransportFactory will let THttpClient write a broken string to server, which making server freezed in transport.readall() method.

After some debugging, I discovered that this is because TCyBufferedTransport [flushes its underlying transport when its buffer size will be exceeded by a write.](https://github.com/Thriftpy/thriftpy2/tree/b78720e22905ba48e044b7a0d1437def3aec923d/thriftpy2/transport/buffered/cybuffered.pyx#L54) For streaming transports, like TSocket, this isn't an issue. However, for HTTP (and other message based transports) the flush method creates a request and sends that to the server. The request is supposed to be a complete Thrift message, however the early flushing behavior of TCyBufferedTransport causes an incomplete message to be sent. 

My proposed solution is to not flush the underlying transport until `TCyBufferedTransport`'s `flush()` or `c_flush()` methods are called directly. I did this by adding `c_dump_wbuf()` which checks if there is data to write and, if so will, writes the data into the underlying transport and then clears the write buffer. Now, when the write buffer is too full, this method is used to empty the buffer into the underlying transport without flushing it. `c_flush()` can then be simplified to dump the write buffer and then flush the underlying transport.

------------
For anyone else who comes across the other issues listed in the comments of http.py:
- `Cannot convert TBufferedTransport to thriftpy2.transport.cybase.CyTransportBase` is caused by [TCyBinaryProtocol declaring the transport as a CyTransportBase for performance.](https://github.com/Thriftpy/thriftpy2/tree/b78720e22905ba48e044b7a0d1437def3aec923d/thriftpy2/protocol/cybin/cybin.pyx#L410) Wrapping your custom transport in TBufferedTransport (which would end up being TCyBufferedTransport) solves this issue because it doesn't care about the type of the wrapped transport.
- `too small buffer allocated by TCyBufferedTransport` is caused by [passing a buffer size less than 1024 to TCyBufferedTransport.](https://github.com/Thriftpy/thriftpy2/tree/b78720e22905ba48e044b7a0d1437def3aec923d/thriftpy2/transport/buffered/cybuffered.pyx#L20) The HTTP client is passing this value explicitly to make sure only one call was every made to `self.rfile.read(size)` because an over-read like the buffered transports normally do can cause the read socket to timeout. I'm not sure why this occurs, since normal sockets typically just return what they have at the moment up to size, but I fought with it for about an hour before deciding to work around it.

I was able to fix these two issues and enable arbitrary server transport support by simply pre-reading the full content into a BytesIO (which is what was internally happening anyways with the buf_size hack) and passing that to whatever transport factory the user chooses.