### PR TITLE
Send TApplicationException to client if raised

### DIFF
--- a/tests/addressbook.thrift
+++ b/tests/addressbook.thrift
@@ -43,4 +43,5 @@ service AddressBookService {
     map<PhoneType, string> get_phones(1: string name);
     bool sleep(1: i32 ms);
     void close(1: i32 ms);
+    void raises(1: string msg);
 }

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -74,6 +74,9 @@ class Dispatcher(object):
     def close(self, ms):
         return
 
+    def raises(self, msg):
+        raise TApplicationException(message=msg)
+
 
 @pytest.fixture(scope="module")
 def server(request):
@@ -273,3 +276,14 @@ def test_ssl_client_timeout():
 def test_close_method():
     with client() as c:
         c.tclose(1)
+
+
+def test_raises_method():
+    with client() as c:
+        try:
+            c.raises("foobarbaz")
+        except TApplicationException as e:
+            assert e.type == 0
+            assert e.message == "foobarbaz"
+        else:
+            raise ValueError("TApplicationException not raised")

--- a/thriftpy2/thrift.py
+++ b/thriftpy2/thrift.py
@@ -319,6 +319,8 @@ class TProcessor(object):
 
         try:
             result.success = call()
+        except TApplicationException as e:
+            return self.send_exception(oprot, api, e, seqid)
         except Exception as e:
             # raise if api don't have throws
             if not self.handle_exception(e, result):


### PR DESCRIPTION
Currently `TApplicationException` raised from user's codes (RPC handler) will be treated as normal Pyhthon error. But if we can send it to client, it will be convenient to use it to handle any unknown exceptions.