### PR TITLE
Raise an exception when duplicate names parsed

### DIFF
--- a/tests/parser-cases/e_duplicate_exception.thrift
+++ b/tests/parser-cases/e_duplicate_exception.thrift
@@ -1,0 +1,8 @@
+exception FooExc {
+    1:string detail,
+}
+
+
+exception FooExc {
+    1:i64 code,
+}

--- a/tests/parser-cases/e_duplicate_function.thrift
+++ b/tests/parser-cases/e_duplicate_function.thrift
@@ -1,0 +1,4 @@
+service FooSvc {
+    i32 do_foo(1:i32 foo),
+    void do_foo(1:i64 foo),
+}

--- a/tests/parser-cases/e_duplicate_service.thrift
+++ b/tests/parser-cases/e_duplicate_service.thrift
@@ -1,0 +1,7 @@
+service FooSvc {
+    i32 do_foo(1:i32 foo),
+}
+
+service FooSvc {
+    i32 do_bar(1:i32 bar),
+}

--- a/tests/parser-cases/e_duplicate_struct.thrift
+++ b/tests/parser-cases/e_duplicate_struct.thrift
@@ -1,0 +1,7 @@
+struct Foo {
+    1:i64 foo_id
+}
+
+struct Foo {
+    1:string foo_idstring
+}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -225,6 +225,24 @@ def test_e_duplicate_field_id_or_name():
     assert 'field identifier/name has already been used' in str(excinfo.value)
 
 
+def test_e_duplicate_struct_exception_service():
+    with pytest.raises(ThriftGrammerError) as excinfo:
+        load('parser-cases/e_duplicate_struct.thrift')
+    assert 'type is already defined in' in str(excinfo.value)
+    with pytest.raises(ThriftGrammerError) as excinfo:
+        load('parser-cases/e_duplicate_exception.thrift')
+    assert 'type is already defined in' in str(excinfo.value)
+    with pytest.raises(ThriftGrammerError) as excinfo:
+        load('parser-cases/e_duplicate_service.thrift')
+    assert 'type is already defined in' in str(excinfo.value)
+
+
+def test_e_duplicate_function():
+    with pytest.raises(ThriftGrammerError) as excinfo:
+        load('parser-cases/e_duplicate_function.thrift')
+    assert 'function is already defined in' in str(excinfo.value)
+
+
 def test_thrift_meta():
     thrift = load('parser-cases/tutorial.thrift')
     meta = thrift.__thrift_meta__

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -660,6 +660,10 @@ def _add_thrift_meta(key, val):
     else:
         meta = getattr(thrift, '__thrift_meta__')
 
+    if key != 'consts' and val.__name__ in [x.__name__ for x in meta[key]]:
+        raise ThriftGrammerError(('\'%s\' type is already defined in '
+                                  '\'%s\'') % (val.__name__, key))
+
     meta[key].append(val)
 
 
@@ -890,6 +894,10 @@ def _make_service(name, funcs, extends):
 
     for func in funcs:
         func_name = func[2]
+        if func_name in thrift_services:
+            raise ThriftGrammerError(('\'%s\' function is already defined in '
+                                      'service \'%s\'') % (func_name,
+                                                           name))
         # args payload cls
         args_name = '%s_args' % func_name
         args_fields = func[3]


### PR DESCRIPTION
See https://github.com/Thriftpy/thriftpy2/issues/166. This is a deadbrain first draft. Consts gets a special exception because it's always types without a `__name__` attribute--I don't think this case matters for them anyway.