### PR TITLE
fix issue that py3.4 cannot use pytest due to latest attr dropping support.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ commands =
     py.test
 
 deps =
+    attrs==20.3.0; python_version == '3.4'
+    typing; python_version == '3.4'
     pytest
     coverage
     pytest-cov


### PR DESCRIPTION
try to fix #174 