### PR TITLE
yield from is necessary when using coroutine in aio

### DIFF
--- a/thriftpy2/contrib/aio/processor.py
+++ b/thriftpy2/contrib/aio/processor.py
@@ -62,7 +62,7 @@ class TAsyncProcessor(object):
         api, seqid, result, call = yield from self.process_in(iprot)
 
         if isinstance(result, TApplicationException):
-            return self.send_exception(oprot, api, result, seqid)
+            return (yield from self.send_exception(oprot, api, result, seqid))
 
         try:
             result.success = yield from call()

--- a/thriftpy2/contrib/aio/protocol/binary.py
+++ b/thriftpy2/contrib/aio/protocol/binary.py
@@ -97,7 +97,7 @@ def read_val(inbuf, ttype, spec=None, decode_response=True):
 
     elif ttype == TType.BINARY:
         sz = unpack_i32((yield from inbuf.read(4)))
-        return inbuf.read(sz)
+        return (yield from inbuf.read(sz))
 
     elif ttype == TType.STRING:
         sz = unpack_i32((yield from inbuf.read(4)))


### PR DESCRIPTION
Some functions returns a coroutine.
`yield from` is necessary for them.