### PR TITLE
close TSocket socket after server disconnect

### DIFF
--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -49,7 +49,7 @@ class TestTSocket:
         mock_sock.close.assert_called_once()
         assert client_socket.sock is None
 
-    def test_disconnect__shutdown_OSError(self):
+    def test_close__shutdown_OSError(self):
         """An OSError on socket shutdown will still close the socket."""
         mock_sock = mock.Mock()
         client_socket = TSocket(sock=mock_sock)
@@ -59,7 +59,7 @@ class TestTSocket:
         mock_sock.close.assert_called_once()
         assert client_socket.sock is None
 
-    def test_disconnect__close_OSError(self):
+    def test_close__close_OSError(self):
         """An OSError on socket close will still clear out the socket."""
         mock_sock = mock.Mock()
         client_socket = TSocket(sock=mock_sock)

--- a/thriftpy2/transport/socket.py
+++ b/thriftpy2/transport/socket.py
@@ -144,8 +144,12 @@ class TSocket(object):
 
         try:
             self.sock.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+            
+        try:
             self.sock.close()
-        except (socket.error, OSError):
+        except OSError:
             pass
         self.sock = None
 


### PR DESCRIPTION
This is similar to: https://github.com/redis/redis-py/pull/1797

Currently, `TSocket.close()` won't continue to close the socket if it encounters an `OSError` on `socket.shutdown`. An `OSError` can happen on `socket.shutdown` if the server side of the connection disconnected already. Not running `socket.close` prevents garbage collection from cleaning up the socket and will use more memory than necessary (maybe even causing a leak?).

This PR puts a separate try/except around `socket.close` and `socket.shutdown` to allow the socket to be closed after a failed shutdown.