### PR TITLE
fix error under python 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(name="thriftpy2",
       long_description=open("README.rst").read(),
       install_requires=install_requires,
       tests_require=tornado_requires,
-      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
       extras_require={
           "dev": dev_requires,
           "tornado": tornado_requires
@@ -112,6 +112,8 @@ setup(name="thriftpy2",
           "Programming Language :: Python :: 3.7",
           "Programming Language :: Python :: 3.8",
           "Programming Language :: Python :: 3.9",
+          "Programming Language :: Python :: 3.10",
+          "Programming Language :: Python :: 3.11",
           "Programming Language :: Python :: Implementation :: CPython",
           "Programming Language :: Python :: Implementation :: PyPy",
       ])

--- a/thriftpy2/contrib/aio/processor.py
+++ b/thriftpy2/contrib/aio/processor.py
@@ -56,7 +56,7 @@ class TAsyncProcessor(object):
         api, seqid, result, call = await self.process_in(iprot)
 
         if isinstance(result, TApplicationException):
-            return (yield from self.send_exception(oprot, api, result, seqid))
+            return (await self.send_exception(oprot, api, result, seqid))
 
         try:
             result.success = await call()

--- a/thriftpy2/contrib/aio/socket.py
+++ b/thriftpy2/contrib/aio/socket.py
@@ -171,7 +171,7 @@ class TAsyncSocket(object):
                 self.connect_timeout
             )
         except socket.error as e:
-            if e.args[0] == errno.ECONNRESET and MAC_OR_BSD:
+            if e.errno == errno.ECONNRESET and MAC_OR_BSD:
                 # freebsd and Mach don't follow POSIX semantic of recv
                 # and fail with ECONNRESET if peer performed shutdown.
                 # See corresponding comment and code in TSocket::read()
@@ -266,7 +266,7 @@ class TAsyncServerSocket(object):
             try:
                 _sock.connect(self.unix_socket)
             except (socket.error, OSError) as err:
-                if err.args[0] == errno.ECONNREFUSED:
+                if err.errno == errno.ECONNREFUSED:
                     os.unlink(self.unix_socket)
         else:
             _sock = socket.socket(self.socket_family, socket.SOCK_STREAM)
@@ -320,7 +320,7 @@ class StreamHandler(object):
         try:
             buff = await self.reader.read(sz)
         except socket.error as e:
-            if e.args[0] == errno.ECONNRESET and MAC_OR_BSD:
+            if e.errno == errno.ECONNRESET and MAC_OR_BSD:
                 # freebsd and Mach don't follow POSIX semantic of recv
                 # and fail with ECONNRESET if peer performed shutdown.
                 # See corresponding comment and code in TSocket::read()


### PR DESCRIPTION
because of socket.error has deprecated, it should use OSError.errno to detect error number instead.