### PR TITLE
Fixed not specified size issue in read_val(aio)

### DIFF
--- a/thriftpy2/contrib/aio/protocol/binary.py
+++ b/thriftpy2/contrib/aio/protocol/binary.py
@@ -84,7 +84,7 @@ async def read_val(inbuf, ttype, spec=None, decode_response=True):
         return unpack_i32(await inbuf.read(4))
 
     elif ttype == TType.I64:
-        return unpack_i64(await inbuf.read())
+        return unpack_i64(await inbuf.read(8))
 
     elif ttype == TType.DOUBLE:
         return unpack_double(await inbuf.read(8))


### PR DESCRIPTION
There was a size in the existing code, 
but it seems to have been removed while applying async/await.

reference: <https://github.com/Thriftpy/thriftpy2/commit/b4abbdd14dbedbb7f057021d222d7d5b9631ecd1>