### PR TITLE
try to fix ci

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest pytest-asyncio
+        python -m pip install flake8 pytest pytest-asyncio cython
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |


### PR DESCRIPTION
According to https://github.com/actions/setup-python/issues/544 , the latest version of ubuntu dose not provide 3.6 python build cache, so we need pin it to ubuntu 20.04.

And the old version of pip / setuptools which support python 3.6 do not install cython before running the extension building, so we need to install it before install the thriftpy package.