### PR TITLE
fix: compatible with cython3

### DIFF
--- a/thriftpy2/transport/cybase.pyx
+++ b/thriftpy2/transport/cybase.pyx
@@ -87,7 +87,7 @@ cdef class TCyBuffer(object):
         if min_size <= self.buf_size:
             return 0
 
-        cdef int multiples = min_size / self.buf_size
+        cdef int multiples = min_size // self.buf_size
         if min_size % self.buf_size != 0:
             multiples += 1
 


### PR DESCRIPTION
Since cython3 is released, the main change is the default language level bumped to 3. This caused thriftpy2's CI failed (see #219).