### PR TITLE
chore: add pyproject.toml and specify build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "cython>=0.28.4,<4"]

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ except ImportError:
     pass
 
 dev_requires = [
-    "cython>=0.28.4",
     "flake8>=2.5",
     "pytest>=2.8",
     "sphinx-rtd-theme>=0.1.9",
@@ -39,13 +38,6 @@ dev_requires = [
     "pytest>=6.1.1",
 ] + tornado_requires
 
-
-# cython detection
-try:
-    from Cython.Build import cythonize
-    CYTHON = True
-except ImportError:
-    CYTHON = False
 
 cmdclass = {}
 ext_modules = []
@@ -56,11 +48,10 @@ UNIX = platform.system() in ("Linux", "Darwin")
 
 # only build ext in CPython with UNIX platform
 if UNIX and not PYPY:
-    # rebuild .c files if cython available
-    if CYTHON:
-        cythonize("thriftpy2/transport/cybase.pyx")
-        cythonize("thriftpy2/transport/**/*.pyx")
-        cythonize("thriftpy2/protocol/cybin/cybin.pyx")
+    from Cython.Build import cythonize
+    cythonize("thriftpy2/transport/cybase.pyx")
+    cythonize("thriftpy2/transport/**/*.pyx")
+    cythonize("thriftpy2/protocol/cybin/cybin.pyx")
 
     ext_modules.append(Extension("thriftpy2.transport.cybase",
                                  ["thriftpy2/transport/cybase.c"]))


### PR DESCRIPTION
For latest setuptools, the build step has changed a lot. The main change is the build process is in an isolated environment without any pip packages.

thriftpy2's setup.py is using cython in its import stage, so the setuptools' change caused the CI failed (see: #220, except the python3.6, because it's using old version setuptools).

This commit adds the new style `pyproject.toml` and specified cython as the build dependency, so the CI can access cython in build process.

Please note that, when publish thriftpy2 to pypi server, we should using the new way described in https://setuptools.pypa.io/en/latest/userguide/quickstart.html, to build files which will be upload to pypi.

Roughly speaking, running `pip install build; python -m build` instead of `python setup.py sdist bdist_wheel`.