### PR TITLE
add 'strict_decode' option for protocols

### DIFF
--- a/tests/test_protocol_binary.py
+++ b/tests/test_protocol_binary.py
@@ -2,6 +2,8 @@
 
 from io import BytesIO
 
+import pytest
+
 from thriftpy2._compat import u
 from thriftpy2.thrift import TType, TPayload
 from thriftpy2.utils import hexlify
@@ -96,6 +98,14 @@ def test_unpack_binary():
                  b"\xe4\xbd\xa0\xe5\xa5\xbd\xe4\xb8\x96\xe7\x95\x8c")
     assert u("你好世界").encode("utf-8") == proto.read_val(
         bs, TType.STRING, decode_response=False)
+
+
+def test_strict_decode():
+    bs = BytesIO(b"\x00\x00\x00\x0c\x00"  # there is a redundant '\x00'
+                 b"\xe4\xbd\xa0\xe5\xa5\xbd\xe4\xb8\x96\xe7\x95\x8c")
+    with pytest.raises(UnicodeDecodeError):
+        proto.read_val(bs, TType.STRING, decode_response=True,
+                       strict_decode=True)
 
 
 def test_write_message_begin():

--- a/tests/test_protocol_compact.py
+++ b/tests/test_protocol_compact.py
@@ -2,6 +2,8 @@
 
 from io import BytesIO
 
+import pytest
+
 from thriftpy2._compat import u
 from thriftpy2.thrift import TType, TPayload
 from thriftpy2.utils import hexlify
@@ -113,6 +115,15 @@ def test_unpack_binary():
     proto.decode_response = False
 
     assert u('你好世界').encode("utf-8") == proto._read_val(TType.STRING)
+
+
+def test_strict_decode():
+    b, proto = gen_proto(b'\x0c\xe4\xbd\xa0\xe5\xa5\x00'
+                         b'\xbd\xe4\xb8\x96\xe7\x95\x8c')
+    proto.strict_decode = True
+
+    with pytest.raises(UnicodeDecodeError):
+        proto._read_val(TType.STRING)
 
 
 def test_pack_bool():

--- a/thriftpy2/protocol/compact.py
+++ b/thriftpy2/protocol/compact.py
@@ -129,13 +129,14 @@ class TCompactProtocol(TProtocolBase):
     TYPE_BITS = 0x07
     TYPE_SHIFT_AMOUNT = 5
 
-    def __init__(self, trans, decode_response=True):
+    def __init__(self, trans, decode_response=True, strict_decode=False):
         TProtocolBase.__init__(self, trans)
         self._last_fid = 0
         self._bool_fid = None
         self._bool_value = None
         self._structs = []
         self.decode_response = decode_response
+        self.strict_decode = strict_decode
 
     def _get_ttype(self, byte):
         return TTYPES[byte & 0x0f]
@@ -245,7 +246,8 @@ class TCompactProtocol(TProtocolBase):
             try:
                 byte_payload = byte_payload.decode('utf-8')
             except UnicodeDecodeError:
-                pass
+                if self.strict_decode:
+                    raise
         return byte_payload
 
     def _read_bool(self):
@@ -586,8 +588,10 @@ class TCompactProtocol(TProtocolBase):
 
 
 class TCompactProtocolFactory(object):
-    def __init__(self, decode_response=True):
+    def __init__(self, decode_response=True, strict_decode=False):
         self.decode_response = decode_response
+        self.strict_decode = strict_decode
 
     def get_protocol(self, trans):
-        return TCompactProtocol(trans, decode_response=self.decode_response)
+        return TCompactProtocol(trans, decode_response=self.decode_response,
+                                strict_decode=self.strict_decode)


### PR DESCRIPTION
The string field will be encoded into python string (formerly unicode in python2) via UTF-8 encoding, and if the field is not a valid UTF-8 string, current implementatiion will fallback to return the raw bytes.

As a result, there would be a pitfall for users: if someone don't validate the result type and just pass it to database or somewhere else, there would be a dirty data.

This change add a `strict_decode` flag when create protocol (or protocol factory) to progate the `UnicodeDecodeError` to users so the PRC call will be failed as expected.

The flag is not enabled by default for compatibility issue.