### PR TITLE
make the import hook compatible with python3.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ env/
 
 pyvenv.cfg
 share/*
+
+venv

--- a/thriftpy2/hook.py
+++ b/thriftpy2/hook.py
@@ -34,7 +34,7 @@ if sys.version_info >= (3, 4):
             return load_module(self.fullname)
 
         def exec_module(self, module):
-            ...
+            pass
 else:
     class ThriftImporter(object):
         def __init__(self, extension="_thrift"):


### PR DESCRIPTION
Also a little refactor on the old ThriftImporter, since we can using the `is` operator to compare to class instances, so the `__eq__` overload is not needed.

fix: #229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced compatibility with Python 3.4 and later for ThriftImporter functionality.

- **Refactor**
  - Updated import mechanisms to align with Python 3.4+ importlib specifications.

- **Chores**
  - Updated `.gitignore` to include the 'venv' directory, indicating a virtual environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->