### PR TITLE
fix: support annotations in union

### DIFF
--- a/tests/parser-cases/annotations.thrift
+++ b/tests/parser-cases/annotations.thrift
@@ -55,3 +55,7 @@ service foo_service {
   void foo() ( foo = "bar" )
 } (a.b="c")
 
+union foo_union {
+   1: optional bool abc
+   2: optional i32 xyz
+}  (a.b="c")

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -229,7 +229,7 @@ def p_seen_struct(p):
 
 
 def p_union(p):
-    '''union : seen_union '{' field_seq '}' '''
+    '''union : seen_union '{' field_seq '}' type_annotations'''
     val = _fill_in_struct(p[1], p[3])
     _add_thrift_meta('unions', val)
 


### PR DESCRIPTION
fix: support annotations in union

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced support for type annotations in union definitions within the Thrift specification.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->