### PR TITLE
Fix deprecated usage of pytest

### DIFF
--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -348,9 +348,13 @@ class TestDeprecatedTimeoutKwarg:
         is emitted (if any) and that the patch is properly applied by
         consuming the RuntimeError.
         """
-        with pytest.warns(warning),\
-                pytest.raises(RuntimeError):  # Consume error
-            await make_aio_client(addressbook.AddressBookService, **kwargs)
+        if warning:
+            with pytest.warns(warning),\
+                    pytest.raises(RuntimeError):  # Consume error
+                await make_aio_client(addressbook.AddressBookService, **kwargs)
+        else:
+            with pytest.raises(RuntimeError):  # Consume error
+                await make_aio_client(addressbook.AddressBookService, **kwargs)
 
     def _given_timeout(self):
         """Get the timeout provided to TAsyncSocket."""

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -316,14 +316,14 @@ class TestDeprecatedTimeoutKwarg:
 
     This class should be removed when the socket_timeout argument is removed.
     """
-    def setup(self):
+    def setup_method(self):
         # Create and apply a fresh patch for each test.
         self.async_sock = patch(
             'thriftpy2.contrib.aio.rpc.TAsyncSocket',
             side_effect=RuntimeError,
         ).__enter__()
 
-    def teardown_(self):
+    def teardown_method(self):
         self.async_sock.__exit__()  # Clean up patch
 
     @pytest.mark.asyncio

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -250,9 +250,8 @@ def test_exception_iwth_ssl():
 
 def test_client_timeout():
     with pytest.raises(socket.timeout):
-        with pytest.warns(UserWarning):  # Deprecated
-            with client(timeout=500) as c:
-                c.sleep(1000)
+        with client(timeout=500) as c:
+            c.sleep(1000)
 
 
 def test_client_socket_timeout():


### PR DESCRIPTION
Details: 

- https://docs.pytest.org/en/stable/deprecations.html#setup-teardown
- https://docs.pytest.org/en/stable/deprecations.html#using-pytest-warns-none

About the change in the `test_rpc.py`, see the comment below.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Tests**
	- Standardized method names for setup and teardown operations in test classes.
	- Removed a deprecated warning in the `test_client_timeout` function related to client instantiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->