### PR TITLE
Fix a compatible issue with very old version of Python

### DIFF
--- a/thriftpy2/hook.py
+++ b/thriftpy2/hook.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import
 
 import sys
-import importlib.abc
 import importlib.util
 import types
 
@@ -15,6 +14,8 @@ from .parser import load_module
 # specified thrift file does not exists, it raises FileNotFoundError, and skiped
 # the other meta finders in the sys.meta_path.
 if sys.version_info >= (3, 4):
+    import importlib.abc
+
     class ThriftImporter(importlib.abc.MetaPathFinder):
         def __init__(self, extension="_thrift"):
             self.extension = extension


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved compatibility with various Python versions by conditionally importing `importlib.abc` in the Thrift module handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->