### PR TITLE
Add submodule to sys.path when loading child idl file.

### DIFF
--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -45,6 +45,9 @@ def test_load():
     person = ab_2.Person(name='Bob')
     assert person == pickle.loads(pickle.dumps(person))
 
+    list_item = ab_2.container.ListItem()
+    assert list_item == pickle.loads(pickle.dumps(list_item))
+
 
 def test_load_module():
     ab = thriftpy2.load_module("addressbook_thrift")

--- a/thriftpy2/parser/__init__.py
+++ b/thriftpy2/parser/__init__.py
@@ -39,6 +39,9 @@ def load(path,
         fill_incomplete_ttype(thrift, thrift)
     if real_module:
         sys.modules[module_name] = thrift
+        for module in thrift.__thrift_meta__["includes"]:
+            if module not in sys.modules:
+                sys.modules[module.__name__] = module
     return thrift
 
 

--- a/thriftpy2/parser/__init__.py
+++ b/thriftpy2/parser/__init__.py
@@ -37,11 +37,16 @@ def load(path,
                    include_dir=include_dir, encoding=encoding)
     if incomplete_type:
         fill_incomplete_ttype(thrift, thrift)
+
+    # add sub modules to sys.modules recursively
     if real_module:
         sys.modules[module_name] = thrift
-        for module in thrift.__thrift_meta__["includes"]:
+        sub_modules = thrift.__thrift_meta__["includes"][:]
+        while sub_modules:
+            module = sub_modules.pop()
             if module not in sys.modules:
                 sys.modules[module.__name__] = module
+                sub_modules.extend(module.__thrift_meta__["includes"])
     return thrift
 
 


### PR DESCRIPTION
Fixes: https://github.com/Thriftpy/thriftpy2/issues/215

I'm not sure if it's suitable to add the module directly to `sys.path`, maybe is should implement like this:
```python
for module in thrift.__thrift_meta__["includes"]:
    if module not in sys.modules:
        sys.modules[module.__name__+"_thrift"] = module
```
 then use the import hook to make sure pickle will import the suitable module.