### PR TITLE
Remove historical SSL context compatibility for Python2

### DIFF
--- a/tests/test_sslsocket.py
+++ b/tests/test_sslsocket.py
@@ -7,7 +7,6 @@ import threading
 
 import pytest
 
-from thriftpy2._compat import MODERN_SSL
 from thriftpy2.transport import TTransportException, create_thriftpy_context
 from thriftpy2.transport.sslsocket import TSSLSocket, TSSLServerSocket
 

--- a/thriftpy2/_compat.py
+++ b/thriftpy2/_compat.py
@@ -19,9 +19,6 @@ PYPY = "__pypy__" in sys.modules
 UNIX = platform.system() in ("Linux", "Darwin")
 CYTHON = UNIX and not PYPY  # Cython always disabled in pypy and windows
 
-# only Python 2.7.9 and Python 3.4 or above have true ssl context
-MODERN_SSL = sys.version_info >= (2, 7, 9)
-
 if PY3:
     text_type = str
     string_types = (str,)


### PR DESCRIPTION
We will remove the python2 historical compatibility code in thriftpy2 step by step.