### PR TITLE
Add missing init file for cybin module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ if not PYPY:
                                  libraries=libraries))
     ext_modules.append(Extension("thriftpy2.transport.sasl.cysasl",
                                  ["thriftpy2/transport/sasl/cysasl.c"]))
-    ext_modules.append(Extension("thriftpy2.protocol.cybin",
+    ext_modules.append(Extension("thriftpy2.protocol.cybin.cybin",
                                  ["thriftpy2/protocol/cybin/cybin.c"],
                                  libraries=libraries))
 

--- a/thriftpy2/protocol/cybin/__init__.py
+++ b/thriftpy2/protocol/cybin/__init__.py
@@ -1,0 +1,1 @@
+from .cybin import TCyBinaryProtocol, TCyBinaryProtocolFactory

--- a/thriftpy2/protocol/cybin/__init__.py
+++ b/thriftpy2/protocol/cybin/__init__.py
@@ -1,1 +1,1 @@
-from .cybin import TCyBinaryProtocol, TCyBinaryProtocolFactory
+from .cybin import *

--- a/thriftpy2/protocol/cybin/cybin.pyx
+++ b/thriftpy2/protocol/cybin/cybin.pyx
@@ -7,9 +7,8 @@ from cpython cimport bool
 
 import six
 
+from thriftpy2.thrift import TDecodeException
 from thriftpy2.transport.cybase cimport CyTransportBase, STACK_STRING_LEN
-
-from ..thrift import TDecodeException
 
 cdef extern from "endian_port.h":
     int16_t htobe16(int16_t n)


### PR DESCRIPTION
To dismiss the deprecation warning when installing:

```
/home/xxxxx/Codes/thriftpy2/venv/lib/python3.11/site-packages/setuptools/command/build_py.py:202: SetuptoolsDeprecationWarning:     Installing 'thriftpy2.protocol.cybin' as data is deprecated, please list it in `packages`.
    !!


    ############################
    # Package would be ignored #
    ############################
    Python recognizes 'thriftpy2.protocol.cybin' as an importable package,
    but it is not listed in the `packages` configuration of setuptools.

    'thriftpy2.protocol.cybin' has been automatically added to the distribution only
    because it may contain data files, but this behavior is likely to change
    in future versions of setuptools (and therefore is considered deprecated).

    Please make sure that 'thriftpy2.protocol.cybin' is included as a package by using
    the `packages` configuration field or the proper discovery methods
    (for example by using `find_namespace_packages(...)`/`find_namespace:`
    instead of `find_packages(...)`/`find:`).

    You can read more about "package discovery" and "data files" on setuptools
    documentation page.


!!

```