### PR TITLE
Fix typos

### DIFF
--- a/thriftpy2/http.py
+++ b/thriftpy2/http.py
@@ -125,7 +125,7 @@ class THttpServer(TServer):
 
         thttpserver = self
 
-        class RequestHander(http_server.BaseHTTPRequestHandler):
+        class RequestHandler(http_server.BaseHTTPRequestHandler):
             # Don't care about the request path.
 
             def do_POST(self):
@@ -153,7 +153,7 @@ class THttpServer(TServer):
                     self.end_headers()
                     self.wfile.write(otrans.getvalue())
 
-        self.httpd = server_class(server_address, RequestHander)
+        self.httpd = server_class(server_address, RequestHandler)
 
     def serve(self):
         self.httpd.serve_forever()

--- a/thriftpy2/parser/lexer.py
+++ b/thriftpy2/parser/lexer.py
@@ -238,7 +238,7 @@ def t_LITERAL(t):
             if s[i] in maps:
                 val += maps[s[i]]
             else:
-                msg = 'Unexcepted escaping characher: %s' % s[i]
+                msg = 'Unexpected escaping character: %s' % s[i]
                 raise ThriftLexerError(msg)
         else:
             val += s[i]

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -169,7 +169,7 @@ def p_const_ref(p):
         father = child
         child = getattr(child, name, None)
         if child is None:
-            raise ThriftParserError('Cann\'t find name %r at line %d'
+            raise ThriftParserError('Can\'t find name %r at line %d'
                                     % (p[1], p.lineno(1)))
 
     if _get_ttype(child) is None or _get_ttype(father) == TType.I32:


### PR DESCRIPTION
These typos are located in the source code instead of tests, but they are private (inner class) or just the error message, so we assume that this wouldn't break user's code.