### PR TITLE
Move dependencies from setup.py to project.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "cython>=0.28.4,<4"]
+requires = ["setuptools", "cython>=0.28.4,<4", "toml"]
 
 [project]
 name = "thriftpy2"
@@ -9,7 +9,6 @@ authors = [
     {name = "ThriftPy Organization", email = "gotzehsing@gmail.com"},
 ]
 dependencies = [
-    "Cython>=3.0.10",
     "ply>=3.4,<4.0",
     "six~=1.15",
 ]
@@ -37,3 +36,19 @@ classifiers = [
 [project.urls]
 Homepage = "https://thriftpy2.readthedocs.io/"
 Source = "https://github.com/Thriftpy/thriftpy2"
+
+[project.optional-dependencies]
+dev = [
+    "flake8>=2.5",
+    "sphinx-rtd-theme>=0.1.9",
+    "sphinx>=1.3",
+    "pytest-reraise",
+    "pytest>=6.1.1,<8.2.0",
+    "tornado>=4.0,<7.0; python_version>='3.12'",
+    "tornado>=4.0,<6.0; python_version<'3.12'",
+]
+
+tornado = [
+    "tornado>=4.0,<7.0; python_version>='3.12'",
+    "tornado>=4.0,<6.0; python_version<'3.12'",
+]

--- a/setup.py
+++ b/setup.py
@@ -3,37 +3,26 @@
 
 import sys
 import platform
+import toml
 
+from os.path import join, dirname
 from setuptools import setup, find_packages, Extension
 
 
-install_requires = [
-    "ply>=3.4,<4.0",
-    "six~=1.15",
-]
-
-tornado_requires = [
-    "tornado>=4.0,<7.0; python_version>='3.12'",
-    "tornado>=4.0,<6.0; python_version<'3.12'",
-]
+meta = toml.load(join(dirname(__file__), 'pyproject.toml') )
+install_requires = meta["project"]["dependencies"]
+dev_requires = meta["project"]["optional-dependencies"]["dev"]
+tornado_requires = meta["project"]["optional-dependencies"]["tornado"]
 
 try:
     from tornado import version as tornado_version
     if tornado_version < '5.0':
         tornado_requires.append("toro>=0.6")
+        dev_requires.append("toro>=0.6")
 except ImportError:
     # tornado will now only get installed and we'll get the newer one
     pass
 
-dev_requires = [
-    "flake8>=2.5",
-    "sphinx-rtd-theme>=0.1.9",
-    "sphinx>=1.3",
-    "pytest-reraise",
-    "pytest>=6.1.1,<8.2.0",
-] + tornado_requires
-
-cmdclass = {}
 ext_modules = []
 
 # pypy detection
@@ -76,7 +65,6 @@ setup(
           "dev": dev_requires,
           "tornado": tornado_requires
       },
-      cmdclass=cmdclass,
       ext_modules=ext_modules,
       include_package_data=True,
 )


### PR DESCRIPTION
Fix the error when run `python -m build`:
```
        ********************************************************************************
        The following seems to be defined outside of `pyproject.toml`:

        `optional-dependencies = {'dev': ['flake8>=2.5', 'sphinx-rtd-theme>=0.1.9', 'sphinx>=1.3', 'pytest-reraise', 'pytest<8.2.0,>=6.1.1', 'tornado<7.0,>=4.0; python_version >= "3.12"', 'tornado<6.0,>=4.0; python_version < "3.12"'], 'tornado': ['tornado<7.0,>=4.0; python_version >= "3.12"', 'tornado<6.0,>=4.0; python_version < "3.12"']}`

        According to the spec (see the link below), however, setuptools CANNOT
        consider this value unless `optional-dependencies` is listed as `dynamic`.

        https://packaging.python.org/en/latest/specifications/pyproject-toml/#declaring-project-metadata-the-project-table

        To prevent this problem, you can list `optional-dependencies` under `dynamic` or alternatively
        remove the `[project]` table from your file and rely entirely on other means of
        configuration.
        ********************************************************************************
```