### PR TITLE
Allow parser.load_fp without module_name

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -304,6 +304,16 @@ def test_load_fp():
     assert thrift.__thrift_meta__['services'] == [thrift.SharedService]
 
 
+def test_load_fp_without_module_name():
+    thrift = None
+    with open('parser-cases/shared.thrift') as thrift_fp:
+        thrift = load_fp(thrift_fp)
+    assert thrift.__name__ == 'shared_thrift'
+    assert thrift.__thrift_file__ is None
+    assert thrift.__thrift_meta__['structs'] == [thrift.SharedStruct]
+    assert thrift.__thrift_meta__['services'] == [thrift.SharedService]
+
+
 def test_e_load_fp():
     with pytest.raises(ThriftParserError) as excinfo:
         with open('parser-cases/tutorial.thrift') as thrift_fp:

--- a/thriftpy2/parser/__init__.py
+++ b/thriftpy2/parser/__init__.py
@@ -165,11 +165,12 @@ def get_definition(thrift, name, lineno):
             return ref_type
 
 
-def load_fp(source, module_name):
+def load_fp(source, module_name=None):
     """Load thrift file like object as a module.
     """
     thrift = parse_fp(source, module_name)
-    sys.modules[module_name] = thrift
+    if module_name is not None:
+        sys.modules[module_name] = thrift
     return thrift
 
 


### PR DESCRIPTION
Just like `parser.load`, allow omitting the `module_name` to prevent polluting the global `sys.modules`.