### PR TITLE
Use SO_REUSEPORT only for AF_INET sockets

### DIFF
--- a/thriftpy2/contrib/aio/socket.py
+++ b/thriftpy2/contrib/aio/socket.py
@@ -281,7 +281,9 @@ class TAsyncServerSocket(object):
             _sock = socket.socket(self.socket_family, socket.SOCK_STREAM)
 
         _sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        if hasattr(socket, "SO_REUSEPORT"):
+        # valid socket https://github.com/python/cpython/issues/128916
+        valid_family = (socket.AF_INET, socket.AF_INET6)
+        if _sock.family in valid_family and hasattr(socket, "SO_REUSEPORT"):
             try:
                 _sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
             except socket.error as err:

--- a/thriftpy2/transport/socket.py
+++ b/thriftpy2/transport/socket.py
@@ -201,7 +201,9 @@ class TServerSocket(object):
             _sock = socket.socket(self.socket_family, socket.SOCK_STREAM)
 
         _sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        if hasattr(socket, "SO_REUSEPORT"):
+        # valid socket https://github.com/python/cpython/issues/128916
+        valid_family = (socket.AF_INET, socket.AF_INET6)
+        if _sock.family in valid_family and hasattr(socket, "SO_REUSEPORT"):
             try:
                 _sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
             except socket.error as err:


### PR DESCRIPTION
The latest python version changes the behavior, now if it's used with other kind of sockets (ex AF_UNIX) it raises OSError:

https://github.com/python/cpython/issues/128916