### PR TITLE
Allow for omitted `FieldID` in `Field` definitions

### DIFF
--- a/tests/parser-cases/service.thrift
+++ b/tests/parser-cases/service.thrift
@@ -14,8 +14,11 @@ exception NetworkError {
 }
 
 service EmailService {
-    void ping () 
+    void ping ()
         throws (1: NetworkError network_error)
     bool send(1: User recver, 2: User sender, 3: Email email)
         throws (1: NetworkError network_error)
+
+    void receive(Email recver, 12: User user)
+    void empty(Email recver)
 }

--- a/tests/parser-cases/structs.thrift
+++ b/tests/parser-cases/structs.thrift
@@ -17,6 +17,7 @@ struct Email {
 
 struct Dog {
     string name;
+    1: i32 age;
     string nickname;
 }
 

--- a/tests/parser-cases/structs.thrift
+++ b/tests/parser-cases/structs.thrift
@@ -15,6 +15,11 @@ struct Email {
     5: MetaData metadata
 }
 
+struct Dog {
+    string name;
+    string nickname;
+}
+
 
 const Email email = {'subject': 'Hello', 'content': 'Long time no see',
     'sender': {'name': 'jack', 'address': 'jack@gmail.com'},

--- a/tests/parser-cases/structs.thrift
+++ b/tests/parser-cases/structs.thrift
@@ -21,6 +21,10 @@ struct Dog {
     string nickname;
 }
 
+struct Cat {
+    string name;
+}
+
 
 const Email email = {'subject': 'Hello', 'content': 'Long time no see',
     'sender': {'name': 'jack', 'address': 'jack@gmail.com'},

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -208,6 +208,9 @@ def test_structs():
         1: (TType.I32, 'age', False),
         -2: (TType.STRING, 'nickname', False)
     }
+    assert thrift.Cat.thrift_spec == {
+        -1: (TType.STRING, 'name', False),
+    }
 
 
 def test_e_structs():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -205,6 +205,7 @@ def test_structs():
     )
     assert thrift.Dog.thrift_spec == {
         -1: (TType.STRING, 'name', False),
+        1: (TType.I32, 'age', False),
         -2: (TType.STRING, 'nickname', False)
     }
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -227,7 +227,7 @@ def test_e_structs():
 
 def test_service():
     thrift = load('parser-cases/service.thrift')
-    assert thrift.EmailService.thrift_services == ['ping', 'send']
+    assert thrift.EmailService.thrift_services == ['ping', 'send', 'receive', 'empty']
     assert thrift.EmailService.ping_args.thrift_spec == {}
     assert thrift.EmailService.ping_args.default_spec == []
     assert thrift.EmailService.ping_result.thrift_spec == {
@@ -251,6 +251,13 @@ def test_service():
     assert thrift.EmailService.send_result.default_spec == [
         ('success', None), ('network_error', None)
     ]
+    assert thrift.EmailService.receive_args.thrift_spec == {
+        -1: (TType.STRUCT, 'recver', thrift.Email, False),
+        12: (TType.STRUCT, 'user', thrift.User, False),
+    }
+    assert thrift.EmailService.empty_args.thrift_spec == {
+        -1: (TType.STRUCT, 'recver', thrift.Email, False),
+    }
 
 
 def test_service_extends():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -203,6 +203,10 @@ def test_structs():
         recver=thrift.Person(name='chao', address='chao@gmail.com'),
         metadata=thrift.MetaData(tags=set())
     )
+    assert thrift.Dog.thrift_spec == {
+        -1: (TType.STRING, 'name', False),
+        -2: (TType.STRING, 'nickname', False)
+    }
 
 
 def test_e_structs():

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -410,7 +410,7 @@ class CurrentIncompleteType(dict):
 
 
 class CurrentFieldSeqImplicitId(object):
-    def __init__(self, *args, **kwargs):
+    def __init__(self):
         self.index = -1
 
     def get_id(self):

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -8,6 +8,7 @@ IDL Ref:
 from __future__ import absolute_import
 
 import collections
+import itertools
 import os
 import threading
 import types
@@ -348,7 +349,7 @@ def p_field_seq(p):
     '''field_seq : field sep field_seq
                  | field field_seq
                  |'''
-    threadlocal.field_seq_implicit_id = CurrentFieldSeqImplicitId()
+    threadlocal.field_seq_implicit_id = itertools.count(start=-1, step=-1)
     _parse_seq(p)
 
 
@@ -379,7 +380,7 @@ def p_field_id(p):
     '''field_id : INTCONSTANT ':'
                 |'''
     if len(p) == 1:
-        p[0] = threadlocal.field_seq_implicit_id.get_id()
+        p[0] = next(threadlocal.field_seq_implicit_id)
     else:
         p[0] = p[1]
 
@@ -570,7 +571,7 @@ def parse(path, module_name=None, include_dirs=None, include_dir=None,
         threadlocal.include_dirs_ = ['.']
         threadlocal.thrift_cache = {}
         threadlocal.incomplete_type = CurrentIncompleteType()
-        threadlocal.field_seq_implicit_id = CurrentFieldSeqImplicitId()
+        threadlocal.field_seq_implicit_id = itertools.count(start=-1, step=-1)
         threadlocal.initialized = True
 
     # dead include checking on current stack
@@ -657,7 +658,7 @@ def parse_fp(source, module_name, lexer=None, parser=None, enable_cache=True):
         threadlocal.include_dirs_ = ['.']
         threadlocal.thrift_cache = {}
         threadlocal.incomplete_type = CurrentIncompleteType()
-        threadlocal.field_seq_implicit_id = CurrentFieldSeqImplicitId()
+        threadlocal.field_seq_implicit_id = itertools.count(start=-1, step=-1)
         threadlocal.initialized = True
 
     if not module_name.endswith('_thrift'):

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -375,8 +375,13 @@ def p_field(p):
 
 
 def p_field_id(p):
-    '''field_id : INTCONSTANT ':' '''
-    p[0] = p[1]
+    '''field_id : INTCONSTANT ':'
+                |'''
+    if len(p) == 1:
+        # TODO: How do we keep state to decrement this for every field missing and id?
+        p[0] = -1
+    else:
+        p[0] = p[1]
 
 
 def p_field_req(p):

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -348,7 +348,7 @@ def p_field_seq(p):
     '''field_seq : field sep field_seq
                  | field field_seq
                  |'''
-    threadlocal.incomplete_struct_fields = CurrentIncompleteStructFields()
+    threadlocal.field_seq_implicit_id = CurrentFieldSeqImplicitId()
     _parse_seq(p)
 
 
@@ -379,7 +379,7 @@ def p_field_id(p):
     '''field_id : INTCONSTANT ':'
                 |'''
     if len(p) == 1:
-        p[0] = threadlocal.incomplete_struct_fields.set_info((None, p.lineno(0)))
+        p[0] = threadlocal.field_seq_implicit_id.set_info((None, p.lineno(0)))
     else:
         p[0] = p[1]
 
@@ -409,7 +409,7 @@ class CurrentIncompleteType(dict):
         return self.index + 1
 
 
-class CurrentIncompleteStructFields(dict):
+class CurrentFieldSeqImplicitId(dict):
     def __init__(self, *args, **kwargs):
         self.index = -1
 
@@ -571,7 +571,7 @@ def parse(path, module_name=None, include_dirs=None, include_dir=None,
         threadlocal.include_dirs_ = ['.']
         threadlocal.thrift_cache = {}
         threadlocal.incomplete_type = CurrentIncompleteType()
-        threadlocal.incomplete_struct_fields = CurrentIncompleteStructFields()
+        threadlocal.field_seq_implicit_id = CurrentFieldSeqImplicitId()
         threadlocal.initialized = True
 
     # dead include checking on current stack
@@ -658,7 +658,7 @@ def parse_fp(source, module_name, lexer=None, parser=None, enable_cache=True):
         threadlocal.include_dirs_ = ['.']
         threadlocal.thrift_cache = {}
         threadlocal.incomplete_type = CurrentIncompleteType()
-        threadlocal.incomplete_struct_fields = CurrentIncompleteStructFields()
+        threadlocal.field_seq_implicit_id = CurrentFieldSeqImplicitId()
         threadlocal.initialized = True
 
     if not module_name.endswith('_thrift'):

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -378,8 +378,7 @@ def p_field_id(p):
     '''field_id : INTCONSTANT ':'
                 |'''
     if len(p) == 1:
-        # TODO: How do we keep state to decrement this for every field missing and id?
-        p[0] = -1
+        p[0] = threadlocal.incomplete_type.set_info((None, p.lineno(0)))
     else:
         p[0] = p[1]
 

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -379,7 +379,7 @@ def p_field_id(p):
     '''field_id : INTCONSTANT ':'
                 |'''
     if len(p) == 1:
-        p[0] = threadlocal.field_seq_implicit_id.set_info((None, p.lineno(0)))
+        p[0] = threadlocal.field_seq_implicit_id.get_id()
     else:
         p[0] = p[1]
 
@@ -409,12 +409,11 @@ class CurrentIncompleteType(dict):
         return self.index + 1
 
 
-class CurrentFieldSeqImplicitId(dict):
+class CurrentFieldSeqImplicitId(object):
     def __init__(self, *args, **kwargs):
         self.index = -1
 
-    def set_info(self, info):
-        self[self.index] = info
+    def get_id(self):
         self.index -= 1
         return self.index + 1
 

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -410,15 +410,6 @@ class CurrentIncompleteType(dict):
         return self.index + 1
 
 
-class CurrentFieldSeqImplicitId(object):
-    def __init__(self):
-        self.index = -1
-
-    def get_id(self):
-        self.index -= 1
-        return self.index + 1
-
-
 def p_ref_type(p):
     '''ref_type : IDENTIFIER'''
     ref_type = threadlocal.thrift_stack[-1]

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ changedir =
     tests
 
 commands =
-    py.test
+    py.test {posargs}
 
 deps =
     pytest>=6.1.1,<8.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ changedir =
     tests
 
 commands =
-    py.test {posargs}
+    py.test
 
 deps =
     pytest>=6.1.1,<8.2.0


### PR DESCRIPTION
Allows `thriftpy2` to accept `Field` with optional `FieldID`.

## Background

In the Thrift IDL, [the `Field` definition](https://thrift.apache.org/docs/idl#field) looks like this:

```
[15] Field           ::=  FieldID? FieldReq? FieldType Identifier ('=' ConstValue)? XsdFieldOptions ListSeparator?
```

Of concern to this PR is the `FieldID?` portion, which indicates the field ID is optional. For instance, both of these structs are valid:

```thrift
struct Dog {
  1: string name;
}

struct Dog {
  string name;
}
```

In the first case the explicit id of `1` is given to the `name` field, while in the second case the omission of an `id` field is allowed. The correct behavior for fields which omit an id is to automatically assign them an id, starting with `-1` and decrementing backwards. As [the Thrift whitepaper](https://thrift.apache.org/static/files/thrift-20070401.pdf) says:

> To avoid conflicts between manually and automatically assigned identifiers, fields with identifiers omitted are assigned identifiers decrementing from -1, and the language only supports the manual assignment of positive identifiers.

This is what the official `thrift` compiler does, where in the generated code you see this:

```
if self.name is not None:
    oprot.writeFieldBegin('name', TType.STRING, -1)
    oprot.writeString(self.name.encode('utf-8') if sys.version_info[0] == 2 else self.name)
    oprot.writeFieldEnd()

```

## Bug

Now certainly a best practice here is to just simply not omit the `FieldID` from your IDL definitions, and the official `thrift` compiler does warn about this case.

```
[WARNING:/Users/jpollard/Code/thriftpy2/tests/parser-cases/structs.thrift:19] No field key specified for name, resulting protocol may have conflicts or not be backwards compatible!
```

But as noted above, it still generates code using the `-1` scheme. Further, fixing existing usage of the implicit `-1` scheme fields is quite tedious. Since you cannot add an explicit `-1` field id value (so as to allow `thriftpy2` to parse the file), you basically have to do a field migration, adding a new field that does explicitly set an id, migrate all users of the old field to the new one, and the remove the old field.

So ideally, `thriftpy2` would allow for a `Field` definition omitting a `FieldID`. If you try that, however, you end up with the bug reported in https://github.com/Thriftpy/thriftpy2/issues/187, which is this exception, where `token` is the field type of the field omitting its ID:

```
thriftpy2.parser.exc.ThriftGrammerError: Grammer error <token> at line 2
```

To fix this, I updated the `field_id` parser to allow for it to be omitted. If it is, it makes use of a new`threadlocal.field_seq_implicit_id` object to keep state and ensure we decrement only within the scope of the field sequence. I also added some test cases to validate the behavior.

This is my first time using a lexer and parser, and so I am not sure if I did this in a sensible way. Please feel free to let me know if there are alternative ways to approach this.