### PR TITLE
Make flake8 happy

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,8 +16,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.9", "pypy3.10"]
-        os: ["ubuntu-20.04", "windows-latest"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.9", "pypy3.10", "pypy3.11"]
+        os: ["ubuntu-24.04", "windows-latest"]
+        include:
+          - os: "windows-latest"
+            python-version: "3.6"
+          - os: "windows-latest"
+            python-version: "3.7"
 
     steps:
     - uses: actions/checkout@v3

--- a/thriftpy2/hook.py
+++ b/thriftpy2/hook.py
@@ -38,10 +38,8 @@ _imp = ThriftImporter()
 
 
 def install_import_hook():
-    global _imp
     sys.meta_path[:] = [x for x in sys.meta_path if _imp is not x] + [_imp]
 
 
 def remove_import_hook():
-    global _imp
     sys.meta_path[:] = [x for x in sys.meta_path if _imp is not x]


### PR DESCRIPTION
- Fix flake8 lint  warning;
- ubuntu-20.04 has been removed yesterday, so upgrade to ubuntu-24.04. Python 3.6~3.7 is not supported on it, so only test these versions on Windows.