### PR TITLE
Resolve daemon warnings for threading methods

### DIFF
--- a/tests/test_framed_transport.py
+++ b/tests/test_framed_transport.py
@@ -72,7 +72,7 @@ class FramedTransportTestCase(TestCase):
         sock.setblocking(0)
         self.port = sock.getsockname()[-1]
         self.server_thread = threading.Thread(target=self.listen)
-        self.server_thread.setDaemon(True)
+        self.server_thread.daemon = True
         self.server_thread.start()
 
     def listen(self):

--- a/thriftpy2/server.py
+++ b/thriftpy2/server.py
@@ -78,7 +78,7 @@ class TThreadedServer(TServer):
             try:
                 client = self.trans.accept()
                 t = threading.Thread(target=self.handle, args=(client,))
-                t.setDaemon(self.daemon)
+                t.daemon = self.daemon
                 t.start()
             except KeyboardInterrupt:
                 raise


### PR DESCRIPTION
# PR Summary
PR resolves the threading daemon warnings which you can find in the [CI logs](https://github.com/Thriftpy/thriftpy2/actions/runs/14497522639/job/40668929976#step:6:268):
```python
/tmp/thriftpy2/tests/test_framed_transport.py:75: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
    self.server_thread.setDaemon(True)
```
