### PR TITLE
add namespace attributes to __thrift_meta__, then we could access namespace info. 

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -379,5 +379,40 @@ def test_nest_incomplete_type():
     }
 
 
+
+
+def test_namespace_in_sub_thread(reraise, reset_parser_threadlocal):
+    @reraise.wrap
+    def f():
+        thrift = load('parser-cases/tutorial.thrift')
+        assert 'namespaces' in thrift.__thrift_meta__
+        assert thrift.__thrift_meta__['namespaces']['cpp'] == 'tutorial'
+        assert thrift.__thrift_meta__['namespaces']['java'] == 'tutorial'
+        assert thrift.__thrift_meta__['namespaces']['php'] == 'tutorial'
+        assert thrift.__thrift_meta__['namespaces']['perl'] == 'tutorial'
+        assert thrift.__thrift_meta__['namespaces']['haxe'] == 'tutorial'
+        assert thrift.__thrift_meta__['namespaces']['d'] == 'tutorial'
+
+    t = threading.Thread(target=f)
+    t.start()
+    t.join()
+
+
+
+def test_namespaces():
+    thrift = load('parser-cases/tutorial.thrift', include_dirs=['./parser-cases'])
+    
+    # Verify namespaces are correctly stored in __thrift_meta__
+    assert 'namespaces' in thrift.__thrift_meta__
+    namespaces = thrift.__thrift_meta__['namespaces']
+    
+    # Check all namespace declarations from tutorial.thrift
+    assert namespaces['cpp'] == 'tutorial'
+    assert namespaces['d'] == 'tutorial'
+    assert namespaces['java'] == 'tutorial'
+    assert namespaces['php'] == 'tutorial'
+    assert namespaces['perl'] == 'tutorial'
+    assert namespaces['haxe'] == 'tutorial'
+
 def test_issue_121():
     load('parser-cases/issue_121.thrift')

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -90,9 +90,23 @@ def p_cpp_include(p):
 
 def p_namespace(p):
     '''namespace : NAMESPACE namespace_scope IDENTIFIER'''
-    # namespace is useless in thriftpy2
-    # if p[2] == 'py' or p[2] == '*':
-    #     setattr(threadlocal.thrift_stack[-1], '__name__', p[3])
+    thrift = threadlocal.thrift_stack[-1]
+    scope = p[2]      # language identifier, e.g. 'py', 'java', 'cpp'
+    namespace = p[3]  # namespace value, e.g. 'tutorial', 'shared'
+    
+    # Initialize __thrift_meta__ if not exists
+    if not hasattr(thrift, '__thrift_meta__'):
+        meta = collections.defaultdict(list)
+        setattr(thrift, '__thrift_meta__', meta)
+    else:
+        meta = getattr(thrift, '__thrift_meta__')
+    
+    # Initialize 'namespaces' as dict if not exists
+    if 'namespaces' not in meta:
+        meta['namespaces'] = {}
+    
+    # Store namespace information
+    meta['namespaces'][scope] = namespace
 
 
 def p_namespace_scope(p):


### PR DESCRIPTION
add namespace attributes to `__thrift_meta__`, so we could access namespace info. support #294 

```
thrift = load("some.thrift")
namespaces = thrift.__thrift_meta__['namespaces']
cpp_namespace = namespaces.get('cpp')  # get ns by cpp lang
java_namespace = namespaces.get('java')  # get ns by java lang
```