### PR TITLE
Requires Python3.7

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,8 +20,6 @@ jobs:
         os: ["ubuntu-24.04", "windows-latest"]
         include:
           - os: "windows-latest"
-            python-version: "3.6"
-          - os: "windows-latest"
             python-version: "3.7"
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "cython>=0.28.4,<4", "toml"]
+requires = ["setuptools>=68", "cython>=0.28.4,<4", "toml"]
 
 [project]
 name = "thriftpy2"
@@ -12,7 +12,7 @@ dependencies = [
     "ply>=3.4,<4.0",
     "six~=1.15",
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 readme = "README.rst"
 license = {file = "LICENSE"}
 keywords = ["thrift python thriftpy thriftpy2"]
@@ -24,7 +24,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Since we moved most of the metadatas from `setup.py` to `pyproject`, when using setuptools with version 59.6.0 (latest version supports Python3.6), it generates a package with name `UNKNOWN` and version `0.0.0`.

I don't know if it will works if we build the package in higher version of setuptools install it in Python3.6, but 3.6 is a very old version and has been [EOLed more than 3 years](https://devguide.python.org/versions/), so I think we can just not support it in the future and make things simple.