### PR TITLE
feat: optimize error output

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -280,7 +280,7 @@ def test_e_dead_include():
 def test_e_grammar_error_at_eof():
     with pytest.raises(ThriftGrammarError) as excinfo:
         load('parser-cases/e_grammar_error_at_eof.thrift')
-    assert str(excinfo.value) == 'Grammar error at EOF'
+    assert str(excinfo.value) == 'Grammar error at EOF of file path in parser-cases/e_grammar_error_at_eof.thrift'
 
 
 def test_e_use_thrift_reserved_keywords():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -280,7 +280,7 @@ def test_e_dead_include():
 def test_e_grammar_error_at_eof():
     with pytest.raises(ThriftGrammarError) as excinfo:
         load('parser-cases/e_grammar_error_at_eof.thrift')
-    assert str(excinfo.value) == 'Grammar error at EOF of file path in parser-cases/e_grammar_error_at_eof.thrift'
+    assert str(excinfo.value) == "Grammar error at EOF of the file 'parser-cases/e_grammar_error_at_eof.thrift'"
 
 
 def test_e_use_thrift_reserved_keywords():

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -28,8 +28,11 @@ threadlocal = threading.local()
 def p_error(p):
     if p is None:
         raise ThriftGrammarError('Grammar error at EOF')
-    raise ThriftGrammarError('Grammar error %r at line %d' %
-                             (p.value, p.lineno))
+
+    thrift = threadlocal.thrift_stack[-1]
+
+    raise ThriftGrammarError('Grammar error %r at thrift_file_path %s, line %d' %
+                             (p.value, thrift.__thrift_file__, p.lineno))
 
 
 def p_start(p):

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -26,10 +26,9 @@ threadlocal = threading.local()
 
 
 def p_error(p):
-    if p is None:
-        raise ThriftGrammarError('Grammar error at EOF')
-
     thrift = threadlocal.thrift_stack[-1]
+    if p is None:
+        raise ThriftGrammarError('Grammar error at thrift_file_path %s, EOF' % thrift.__thrift_file__)
 
     raise ThriftGrammarError('Grammar error %r at thrift_file_path %s, line %d' %
                              (p.value, thrift.__thrift_file__, p.lineno))

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -28,9 +28,9 @@ threadlocal = threading.local()
 def p_error(p):
     thrift = threadlocal.thrift_stack[-1]
     if p is None:
-        raise ThriftGrammarError('Grammar error at EOF of file path in %s' % thrift.__thrift_file__)
+        raise ThriftGrammarError("Grammar error at EOF of the file '%s'" % thrift.__thrift_file__)
 
-    raise ThriftGrammarError('Grammar error %r at line %d of file path in %s, ' %
+    raise ThriftGrammarError("Grammar error %r at line %d of the file '%s'" %
                              (p.value, p.lineno, thrift.__thrift_file__))
 
 

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -28,10 +28,10 @@ threadlocal = threading.local()
 def p_error(p):
     thrift = threadlocal.thrift_stack[-1]
     if p is None:
-        raise ThriftGrammarError('Grammar error at thrift_file_path %s, EOF' % thrift.__thrift_file__)
+        raise ThriftGrammarError('Grammar error at EOF of file path in %s' % thrift.__thrift_file__)
 
-    raise ThriftGrammarError('Grammar error %r at thrift_file_path %s, line %d' %
-                             (p.value, thrift.__thrift_file__, p.lineno))
+    raise ThriftGrammarError('Grammar error %r at line %d of file path in %s, ' %
+                             (p.value, p.lineno, thrift.__thrift_file__))
 
 
 def p_start(p):


### PR DESCRIPTION
when parsing a grammar error thrift file will output an error stack output as follows:

```
../thriftpy2/parser/__init__.py:36: in load
    thrift = parse(path, module_name, include_dirs=include_dirs,
../thriftpy2/parser/parser.py:623: in parse
    parser.parse(data)
../.venv/lib/python3.12/site-packages/ply/yacc.py:333: in parse
    return self.parseopt_notrack(input, lexer, debug, tracking, tokenfunc)
../.venv/lib/python3.12/site-packages/ply/yacc.py:1120: in parseopt_notrack
    p.callable(pslice)
../thriftpy2/parser/parser.py:77: in p_include
    child = parse(path, module_name=child_module_name)
../thriftpy2/parser/parser.py:623: in parse
    parser.parse(data)
../.venv/lib/python3.12/site-packages/ply/yacc.py:333: in parse
    return self.parseopt_notrack(input, lexer, debug, tracking, tokenfunc)
../.venv/lib/python3.12/site-packages/ply/yacc.py:1201: in parseopt_notrack
    tok = call_errorfunc(self.errorfunc, errtoken, self)
../.venv/lib/python3.12/site-packages/ply/yacc.py:192: in call_errorfunc
    r = errorfunc(token)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

p = LexToken(,,',',341,4843)

    def p_error(p):
        if p is None:
            raise ThriftGrammarError('Grammar error at EOF')
    
>       raise ThriftGrammarError('Grammar error %r at line %d' %
                                 (p.value, p.lineno))
E       thriftpy2.parser.exc.ThriftGrammarError: Grammar error ',' at line 341

../thriftpy2/parser/parser.py:33: ThriftGrammarError
```

the last stack only output the file num ` thriftpy2.parser.exc.ThriftGrammarError: Grammar error ',' at line 341`, the problem is that with the file path missing, it's hard to locate the grammar error is in which file, so we should output the file path also.

```python
def p_error(p):
    thrift = threadlocal.thrift_stack[-1]
    if p is None:
        raise ThriftGrammarError('Grammar error at EOF of file path in %s' % thrift.__thrift_file__)

    raise ThriftGrammarError('Grammar error %r at line %d of file path in %s, ' %
                             (p.value, p.lineno, thrift.__thrift_file__))
```

and we'll get the optimized output as follows:

```
../thriftpy2/parser/__init__.py:36: in load
    thrift = parse(path, module_name, include_dirs=include_dirs,
../thriftpy2/parser/parser.py:625: in parse
    parser.parse(data)
../.venv/lib/python3.12/site-packages/ply/yacc.py:333: in parse
    return self.parseopt_notrack(input, lexer, debug, tracking, tokenfunc)
../.venv/lib/python3.12/site-packages/ply/yacc.py:1120: in parseopt_notrack
    p.callable(pslice)
../thriftpy2/parser/parser.py:79: in p_include
    child = parse(path, module_name=child_module_name)
../thriftpy2/parser/parser.py:625: in parse
    parser.parse(data)
../.venv/lib/python3.12/site-packages/ply/yacc.py:333: in parse
    return self.parseopt_notrack(input, lexer, debug, tracking, tokenfunc)
../.venv/lib/python3.12/site-packages/ply/yacc.py:1201: in parseopt_notrack
    tok = call_errorfunc(self.errorfunc, errtoken, self)
../.venv/lib/python3.12/site-packages/ply/yacc.py:192: in call_errorfunc
    r = errorfunc(token)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

p = LexToken(,,',',341,4843)

    def p_error(p):
        if p is None:
            raise ThriftGrammarError('Grammar error at EOF')
    
        thrift = threadlocal.thrift_stack[-1]
    
>       raise ThriftGrammarError('Grammar error %r at thrift_file_path %s, line %d' %
                                 (p.value, thrift.__thrift_file__, p.lineno))
E       thriftpy2.parser.exc.ThriftGrammarError: Grammar error ','  at line 341 of file path in /Users/xxx/Projects/GitHub/thriftpy2/test.thrift

../thriftpy2/parser/parser.py:35: ThriftGrammarError
```

