### PR TITLE
Make `TPayload` hashable

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -44,9 +44,8 @@ def test_hashable():
     # exception is hashable
     hash(ab.PersonNotExistsError("test error"))
 
-    # container struct is not hashable
-    with pytest.raises(TypeError):
-        hash(ab.Person(name="Tom"))
+    # container struct is hashable
+    hash(ab.Person(name="Tom"))
 
 
 def test_default_value():

--- a/thriftpy2/thrift.py
+++ b/thriftpy2/thrift.py
@@ -149,7 +149,8 @@ def gen_init(cls, thrift_spec=None, default_spec=None):
 
 class TPayload(metaclass=TPayloadMeta):
 
-    __hash__ = None
+    def __hash__(self):
+        return super(TPayload, self).__hash__()
 
     def read(self, iprot):
         iprot.read_struct(self)


### PR DESCRIPTION
We've been using Thriftpy2 successfully for a little while, however have run into what we consider a bug.

When a `TPayload` (which I understand to be a struct, union, or exception) is used as the key inside a Thrift map, the binary protocol will [attempt to store that `TPayload` value as the key in a `dict`](https://github.com/Thriftpy/thriftpy2/blob/c37c1e01ea3d77bd59b9303b6ffb121c848ca526/thriftpy2/protocol/binary.py#L306). Because [`TPayload.__hash__` is set to `None`](https://github.com/Thriftpy/thriftpy2/blob/c37c1e01ea3d77bd59b9303b6ffb121c848ca526/thriftpy2/thrift.py#L152), this makes `TPayload` instances unhashable, and so they can't be used for `dict` keys and instead throw this exception:

```
TypeError: unhashable type: 'Person'
```

Now `TPayload.__hash__` is set to `None` was done intentionally in https://github.com/thriftpy/thriftpy2/commit/daa213d719743bf2e0f1db0d972ee622bc69102c apparently to fix https://github.com/Thriftpy/thriftpy2/pull/184. There are skim details on this motivation and that particular issue, but later `TException` was made hashable in https://github.com/thriftpy/thriftpy2/commit/40219d4ac57c86916d8bbdcf1b1aeb63ad2f4b4b, again with skim details.

Given structs and unions are viable Thrift `map` keys, I would consider the current behavior a bug. The most direct fix is just to restore the old `TPayload.__hash__` logic. That makes `TPayload` hashable, but I am not sure if this is a good idea as it was purposefully made unhashable. Though that fix was from 2016, nearly 10 years ago, and so I am wondering if the fix is still needed?

The less direct way to fix this is to have the binary protocol (and also the compact protocol) read a map not into a vanilla Python `dict`, but into some custom type that implements `__contains__` and is otherwise duck-typed like a `dict`, but does not `hash(key)` if `key` is a `TPayload`, instead doing some other thing.

This PR implements the direct fix, but again let me know that is a bad idea. If so I can do the less direct fix, or another fix you think is more appropriate. Happy to fixup this PR to implement whatever.