### PR TITLE
Update cibuildwheel and remove build on macos-13

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-python@v5
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==3.3.1
+        run: python -m pip install cibuildwheel>=3.3.1,<4.0.0
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse


### PR DESCRIPTION
- Update cibuildwheel to support build wheels for Python3.14;
- Remove build wheels for macOS with Intel chips because GitHub dropped the CI environment.