### PR TITLE
Add Windows ARM64 support in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,10 +21,23 @@ jobs:
           "3.13", "3.13t", "3.14", "3.14t",
           "pypy3.9", "pypy3.10", "pypy3.11",
         ]
-        os: ["ubuntu-24.04", "windows-latest"]
+        os: ["ubuntu-24.04", "windows-latest", "windows-11-arm"]
         include:
           - os: "windows-latest"
             python-version: "3.7"
+        exclude:
+          - os: "windows-11-arm"
+            python-version: "3.8"
+          - os: "windows-11-arm"
+            python-version: "3.9"
+          - os: "windows-11-arm"
+            python-version: "3.10"
+          - os: "windows-11-arm"
+            python-version: "pypy3.9"
+          - os: "windows-11-arm"
+            python-version: "pypy3.10"
+          - os: "windows-11-arm"
+            python-version: "pypy3.11"
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds Windows ARM64 support to the CI test and build matrix.

- Adds `windows-11-arm` to the os matrix in both Test and Build workflows.
- In Test, excludes Python 3.8, 3.9, 3.10 and all PyPy versions as they are not supported on Windows ARM64.