### PR TITLE
Use ijson to stream-parse Apache JSON requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [
 ]
 dependencies = [
     "ply>=3.4,<4.0",
+    "ijson>=3.0,<4.0",
     "typing_extensions>=3.7.4; python_version<'3.8'",
 ]
 requires-python = ">=3.7"

--- a/tests/test_apache_json.py
+++ b/tests/test_apache_json.py
@@ -4,14 +4,16 @@ from __future__ import absolute_import
 import json
 import sys
 import time
+from io import BytesIO
 from multiprocessing import Process
 
 import pytest
 
 import thriftpy2
 from thriftpy2.http import make_server as make_http_server, \
-    make_client as make_http_client
+    make_client as make_http_client, TFileObjectTransport
 from thriftpy2.protocol import TApacheJSONProtocolFactory
+from thriftpy2.protocol.apache_json import TApacheJSONProtocol
 from thriftpy2.rpc import make_server as make_rpc_server, \
     make_client as make_rpc_client
 from thriftpy2.thrift import TProcessor, TType
@@ -124,6 +126,25 @@ def test_thrift_transport():
     final_data = obuf.getvalue()
     assert json.loads(request_data.decode('utf8'))[4]['1'] == \
            json.loads(final_data.decode('utf8'))[4]['0']
+
+
+def test_streaming_parse_backslash_string():
+    """Regression: a JSON string containing a single backslash used to break
+    the old byte-by-byte scanner because it treated the closing quote of
+    ``"\\"`` as escaped, leaving in_string=True and never closing the array.
+
+    The streaming path (no getvalue) must parse this correctly via ijson.
+    """
+    inner = chr(0x5C)  # single backslash
+    doc = [1, "x", 1, 0, {"1": {"rec": {"7": {"str": inner}}}}]
+    payload = json.dumps(doc, separators=(",", ":")).encode("utf8")
+    # TFileObjectTransport has no getvalue(), so we hit the ijson path.
+    trans = TFileObjectTransport(BytesIO(payload))
+    assert not hasattr(trans, "getvalue")
+    proto = TApacheJSONProtocol(trans)
+    proto._load_data()
+    assert proto._req[1:4] == ["x", 1, 0]
+    assert proto._req[4]["1"]["rec"]["7"]["str"] == inner
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="this test requires fork")

--- a/thriftpy2/protocol/apache_json.py
+++ b/thriftpy2/protocol/apache_json.py
@@ -5,11 +5,10 @@ Transport for json protocol that apache thrift files will understand
 unfortunately, thriftpy2's TJSONProtocol is not compatible with apache's
 """
 
-from __future__ import absolute_import
 import json
 import base64
-import sys
 
+import ijson
 
 from thriftpy2.protocol import TProtocolBase
 from thriftpy2.thrift import TType
@@ -66,6 +65,25 @@ def _ensure_b64_encode(val):
     return val
 
 
+class _ListSink(object):
+    """Minimal coroutine-like sink for ijson's items_coro pipeline.
+
+    ijson's chained-coroutine API calls ``target.send(item)`` on its sink, so
+    a plain ``list.append`` won't work as a target. This wrapper exposes a
+    ``send`` (and ``close``) so a list can act as the sink directly.
+    """
+    __slots__ = ('_target',)
+
+    def __init__(self, target):
+        self._target = target
+
+    def send(self, item):
+        self._target.append(item)
+
+    def close(self):
+        pass
+
+
 class TApacheJSONProtocolFactory(object):
     def get_protocol(self, trans):
         return TApacheJSONProtocol(trans)
@@ -81,34 +99,35 @@ class TApacheJSONProtocol(TProtocolBase):
         self._req = None
 
     def _load_data(self):
-        data = b""
-        l_braces = 0
-        in_string = False
-        while True:
-            # read(sz) will wait until it has read exactly sz bytes,
-            # so we must read until we get a balanced json list in absence of knowing
-            # how long the json string will be
-            if hasattr(self.trans, 'getvalue'):
-                try:
-                    data = self.trans.getvalue()
+        # Fast path: transports that buffer the whole message expose getvalue()
+        if hasattr(self.trans, 'getvalue'):
+            try:
+                data = self.trans.getvalue()
+                self._req = json.loads(data.decode('utf8')) if data else None
+                return
+            except Exception:
+                pass
+
+        # Streaming path: feed bytes to ijson's push parser; stop the moment
+        # the top-level value is fully materialized. trans.read(n) blocks until
+        # exactly n bytes arrive and Apache JSON has no length prefix, so we
+        # must read one byte at a time to avoid consuming past the message end.
+        items = []
+        sink = _ListSink(items)
+        coro = ijson.items_coro(sink, '')
+        try:
+            while not items:
+                chunk = self.trans.read(1)
+                if not chunk:
                     break
-                except Exception:
-                    pass
-            new_data = self.trans.read(1)
-            data += new_data
-            if new_data == b'"' and not data.endswith(b'\\"'):
-                in_string = not in_string
-            if not in_string:
-                if new_data == b"[":
-                    l_braces += 1
-                elif new_data == b"]":
-                    l_braces -= 1
-            if l_braces == 0:
-                break
-        if data:
-            self._req = json.loads(data.decode('utf8'))
-        else:
-            self._req = None
+                coro.send(chunk)
+        finally:
+            try:
+                coro.close()
+            except Exception:
+                pass
+
+        self._req = items[0] if items else None
 
     def read_message_begin(self):
         if not self._req:


### PR DESCRIPTION
Replaces the byte-by-byte scanner in `TApacheJSONProtocol._load_data` with ijson's push parser. Fixes a hang when a JSON string value ends with a backslash followed by the closing quote, and removes the O(N^2) bytes concatenation plus the redundant second `json.loads` pass.