### PR TITLE
Fix SASL client transport read and negotiation bugs

### DIFF
--- a/tests/test_sasl.py
+++ b/tests/test_sasl.py
@@ -1,0 +1,212 @@
+import struct
+
+import pytest
+
+import thriftpy2.transport.sasl as sasl_module
+from thriftpy2._compat import CYTHON
+from thriftpy2.transport import TTransportException
+
+START = 1
+OK = 2
+BAD = 3
+ERROR = 4
+COMPLETE = 5
+
+
+class FakeSaslClient(object):
+    """Mimics the interface of sasl.Client.
+
+    With wrap=False it behaves like a QOP=auth negotiation where
+    encode/decode pass data through unchanged. With wrap=True it
+    emulates auth-int/auth-conf by adding a length header and a one
+    byte marker around the payload.
+    """
+
+    def __init__(self, mechanism=b'PLAIN', initial=b'initial', wrap=False):
+        self.mechanism = mechanism
+        self.initial = initial
+        self.wrap = wrap
+        self.challenges = []
+
+    def start(self, mechanism):
+        return True, self.mechanism, self.initial
+
+    def step(self, challenge):
+        self.challenges.append(challenge)
+        return True, b'response'
+
+    def encode(self, data):
+        if self.wrap:
+            wrapped = b'X' + data
+            return True, struct.pack('>I', len(wrapped)) + wrapped
+        return True, data
+
+    def decode(self, data):
+        # data contains the 4 byte length header plus the wrapped payload
+        return True, data[5:]
+
+    def getError(self):
+        return 'fake sasl error'
+
+
+class LoopbackTransport(object):
+    """In-memory transport with scripted input and recorded output."""
+
+    def __init__(self, inbuf=b''):
+        self.inbuf = inbuf
+        self.out = []
+        self.opened = True
+
+    def is_open(self):
+        return self.opened
+
+    def open(self):
+        self.opened = True
+
+    def close(self):
+        self.opened = False
+
+    def read(self, sz):
+        ret, self.inbuf = self.inbuf[:sz], self.inbuf[sz:]
+        return ret
+
+    def write(self, data):
+        self.out.append(data)
+
+    def flush(self):
+        pass
+
+
+def sasl_message(status, payload):
+    return struct.pack('>BI', status, len(payload)) + payload
+
+
+def data_frame(payload):
+    return struct.pack('>I', len(payload)) + payload
+
+
+transport_classes = [sasl_module.TSaslClientTransport]
+if CYTHON:
+    transport_classes.append(sasl_module.TCySaslClientTransport)
+
+
+@pytest.fixture(params=transport_classes,
+                ids=[cls.__name__ for cls in transport_classes])
+def transport_cls(request):
+    return request.param
+
+
+def make_transport(transport_cls, sasl=None, inbuf=b''):
+    sasl = sasl or FakeSaslClient()
+    trans = LoopbackTransport(inbuf)
+    return transport_cls(lambda: sasl, 'PLAIN', trans), sasl, trans
+
+
+def open_transport(transport_cls, sasl=None, inbuf=b''):
+    t, sasl, trans = make_transport(
+        transport_cls, sasl, sasl_message(COMPLETE, b'') + inbuf)
+    t.open()
+    trans.out = []
+    return t, sasl, trans
+
+
+def test_negotiation(transport_cls):
+    server_replies = sasl_message(OK, b'challenge') + sasl_message(COMPLETE, b'')
+    t, sasl, trans = make_transport(transport_cls, inbuf=server_replies)
+    t.open()
+
+    assert trans.out == [
+        sasl_message(START, b'PLAIN'),
+        sasl_message(OK, b'initial'),
+        sasl_message(OK, b'response'),
+    ]
+    assert sasl.challenges == [b'challenge']
+
+
+def test_negotiation_with_str_mechanism_and_none_initial(transport_cls):
+    sasl = FakeSaslClient(mechanism='PLAIN', initial=None)
+    t, sasl, trans = make_transport(
+        transport_cls, sasl, sasl_message(COMPLETE, b''))
+    t.open()
+
+    assert trans.out == [
+        sasl_message(START, b'PLAIN'),
+        sasl_message(OK, b''),
+    ]
+
+
+def test_negotiation_bad_status(transport_cls):
+    t, _, _ = make_transport(
+        transport_cls, inbuf=sasl_message(BAD, b'denied'))
+    with pytest.raises(TTransportException, match='Bad status'):
+        t.open()
+
+
+def test_open_twice(transport_cls):
+    t, _, _ = open_transport(transport_cls)
+    with pytest.raises(TTransportException, match='Already open') as exc:
+        t.open()
+    assert exc.value.type == TTransportException.ALREADY_OPEN
+
+
+def test_write_flush_plain(transport_cls):
+    t, _, trans = open_transport(transport_cls)
+    t.write(b'hello')
+    t.flush()
+    assert trans.out == [data_frame(b'hello')]
+
+
+def test_read_within_frame(transport_cls):
+    t, _, trans = open_transport(transport_cls)
+    t.write(b'x')
+    t.flush()  # decide QOP before reading
+
+    trans.inbuf = data_frame(b'\x00\x07abcd')
+    assert t.read(2) == b'\x00\x07'
+    assert t.read(4) == b'abcd'
+
+
+def test_read_across_frames(transport_cls):
+    t, _, trans = open_transport(transport_cls)
+    t.write(b'x')
+    t.flush()
+
+    # one i32 split across two frames, then more data in the second frame
+    trans.inbuf = data_frame(b'\x00\x00') + data_frame(b'\x00\x07abcd')
+    assert t.read(4) == b'\x00\x00\x00\x07'
+    assert t.read(4) == b'abcd'
+
+
+def test_read_eof(transport_cls):
+    t, _, trans = open_transport(transport_cls)
+    t.write(b'x')
+    t.flush()
+
+    trans.inbuf = data_frame(b'ab')
+    with pytest.raises(TTransportException) as exc:
+        t.read(4)
+    assert exc.value.type == TTransportException.END_OF_FILE
+
+
+def test_wrapped_roundtrip(transport_cls):
+    sasl = FakeSaslClient(wrap=True)
+    t, sasl, trans = open_transport(transport_cls, sasl)
+
+    t.write(b'hello')
+    t.flush()  # encode changes the length, so QOP wrapping is detected
+    assert trans.out == [data_frame(b'Xhello')]
+
+    trans.inbuf = data_frame(b'Xworld')
+    assert t.read(5) == b'world'
+
+
+def test_close_and_reopen(transport_cls):
+    t, _, trans = open_transport(transport_cls)
+    t.close()
+    assert not trans.is_open()
+
+    trans.inbuf = sasl_message(COMPLETE, b'')
+    t.open()
+    t.write(b'hello')
+    t.flush()
+    assert trans.out[-1] == data_frame(b'hello')

--- a/tests/test_sasl.py
+++ b/tests/test_sasl.py
@@ -188,6 +188,19 @@ def test_read_eof(transport_cls):
     assert exc.value.type == TTransportException.END_OF_FILE
 
 
+def test_read_empty_frame_does_not_loop(transport_cls):
+    t, _, trans = open_transport(transport_cls)
+    t.write(b'x')
+    t.flush()
+
+    # A stream of zero-length frames yields no data; the read loop must not
+    # spin forever waiting to satisfy the request.
+    trans.inbuf = data_frame(b'') + data_frame(b'')
+    with pytest.raises(TTransportException) as exc:
+        t.read(4)
+    assert exc.value.type == TTransportException.END_OF_FILE
+
+
 def test_wrapped_roundtrip(transport_cls):
     sasl = FakeSaslClient(wrap=True)
     t, sasl, trans = open_transport(transport_cls, sasl)

--- a/thriftpy2/transport/sasl/__init__.py
+++ b/thriftpy2/transport/sasl/__init__.py
@@ -60,7 +60,7 @@ class TSaslClientTransport(TTransportBase):
 
         if self.sasl is not None:
             raise TTransportException(
-                type=TTransportException.NOT_OPEN,
+                type=TTransportException.ALREADY_OPEN,
                 message="Already open!")
         self.sasl = self.sasl_client_factory()
 
@@ -88,6 +88,12 @@ class TSaslClientTransport(TTransportBase):
             self._send_message(self.OK, response)
 
     def _send_message(self, status, body):
+        # Depending on the SASL library, the mechanism name and the initial
+        # response may come back as str or None instead of bytes.
+        if body is None:
+            body = b""
+        elif isinstance(body, str):
+            body = body.encode("utf-8")
         header = struct.pack(">BI", status, len(body))
         self._trans.write(header + body)
         self._trans.flush()
@@ -98,7 +104,7 @@ class TSaslClientTransport(TTransportBase):
         if length > 0:
             payload = readall(self._trans.read, length)
         else:
-            payload = ""
+            payload = b""
         return status, payload
 
     def write(self, data):
@@ -154,11 +160,14 @@ class TSaslClientTransport(TTransportBase):
 
     def read(self, sz):
         ret = self.__rbuf.read(sz)
-        if len(ret) == sz:
-            return ret
-
-        self._read_frame()
-        return ret + self.__rbuf.read(sz - len(ret))
+        # A thrift message may span multiple SASL frames, so keep reading
+        # frames until we have the requested amount of data. The protocol
+        # layer calls read() directly and relies on getting exactly `sz`
+        # bytes (see TTransportBase.read).
+        while len(ret) < sz:
+            self._read_frame()
+            ret += self.__rbuf.read(sz - len(ret))
+        return ret
 
     def _read_frame(self):
         header = readall(self._trans.read, 4)
@@ -180,6 +189,9 @@ class TSaslClientTransport(TTransportBase):
     def close(self):
         self._trans.close()
         self.sasl = None
+        self.encode = None
+        self.__wbuf = BytesIO()
+        self.__rbuf = BytesIO(b'')
 
     # XXX: Is this actually needed?
     # Implement the CReadableTransport interface.

--- a/thriftpy2/transport/sasl/__init__.py
+++ b/thriftpy2/transport/sasl/__init__.py
@@ -166,7 +166,15 @@ class TSaslClientTransport(TTransportBase):
         # bytes (see TTransportBase.read).
         while len(ret) < sz:
             self._read_frame()
-            ret += self.__rbuf.read(sz - len(ret))
+            chunk = self.__rbuf.read(sz - len(ret))
+            if not chunk:
+                # A frame that yields no data (e.g. a zero-length frame or an
+                # empty SASL decode result) would make this loop spin forever
+                # without ever satisfying the request, so treat it as EOF.
+                raise TTransportException(
+                    type=TTransportException.END_OF_FILE,
+                    message="Received empty SASL frame while more data expected")
+            ret += chunk
         return ret
 
     def _read_frame(self):

--- a/thriftpy2/transport/sasl/cysasl.pyx
+++ b/thriftpy2/transport/sasl/cysasl.pyx
@@ -186,6 +186,14 @@ cdef class TCySaslClientTransport(CyTransportBase):
             if avail == 0:
                 self._read_frame()
                 avail = self.__rbuf.data_size
+                if avail == 0:
+                    # A frame that yields no data (e.g. a zero-length frame or
+                    # an empty SASL decode result) would make this loop spin
+                    # forever without ever satisfying the request, so treat it
+                    # as EOF.
+                    raise TTransportException(
+                        type=TTransportException.END_OF_FILE,
+                        message="Received empty SASL frame while more data expected")
             if avail > sz:
                 avail = sz
             ret += self.__rbuf.buf[self.__rbuf.cur:self.__rbuf.cur + avail]

--- a/thriftpy2/transport/sasl/cysasl.pyx
+++ b/thriftpy2/transport/sasl/cysasl.pyx
@@ -53,7 +53,7 @@ cdef class TCySaslClientTransport(CyTransportBase):
 
         if self.sasl is not None:
             raise TTransportException(
-                type=TTransportException.NOT_OPEN,
+                type=TTransportException.ALREADY_OPEN,
                 message="Already open!")
         self.sasl = self.sasl_client_factory()
 
@@ -81,6 +81,12 @@ cdef class TCySaslClientTransport(CyTransportBase):
             self._send_message(self.OK, response)
 
     def _send_message(self, status, body):
+        # Depending on the SASL library, the mechanism name and the initial
+        # response may come back as str or None instead of bytes.
+        if body is None:
+            body = b""
+        elif isinstance(body, str):
+            body = body.encode("utf-8")
         header = struct.pack(">BI", status, len(body))
         self.trans.write(header + body)
         self.trans.flush()
@@ -91,7 +97,7 @@ cdef class TCySaslClientTransport(CyTransportBase):
         if length > 0:
             payload = readall(self.trans.read, length)
         else:
-            payload = ""
+            payload = b""
         return status, payload
 
     def write(self, bytes data):
@@ -140,7 +146,6 @@ cdef class TCySaslClientTransport(CyTransportBase):
 
             self.trans.flush()
             self.__wbuf.clean()
-        return("DUN FLUSHING IN SASL")
 
     def _flushEncoded(self, buffer):
         # sasl.ecnode() does the encoding and adds the length header, so nothing
@@ -166,25 +171,30 @@ cdef class TCySaslClientTransport(CyTransportBase):
         return self.get_string(sz)
 
     cdef c_read(self, int sz, char* out):
-        cdef bytes ret
-
-        ret = b""
+        cdef:
+            bytes ret = b""
+            int orig_sz = sz
+            int avail
 
         if sz <= 0:
             return 0
 
-        orig_sz = sz
-        if self.__rbuf.data_size < sz:
-            # Read what remains, then get more data plz
-            ret += self.__rbuf.buf[:self.__rbuf.data_size]
-            sz -= self.__rbuf.data_size
-            self._read_frame()
-
-        ret += self.__rbuf.buf[self.__rbuf.cur:self.__rbuf.cur + sz]
-        self.__rbuf.cur += sz
-        self.__rbuf.data_size -= sz
+        # A thrift message may span multiple SASL frames, so keep reading
+        # frames until we have the requested amount of data.
+        while sz > 0:
+            avail = self.__rbuf.data_size
+            if avail == 0:
+                self._read_frame()
+                avail = self.__rbuf.data_size
+            if avail > sz:
+                avail = sz
+            ret += self.__rbuf.buf[self.__rbuf.cur:self.__rbuf.cur + avail]
+            self.__rbuf.cur += avail
+            self.__rbuf.data_size -= avail
+            sz -= avail
 
         memcpy(out, <char*>ret, orig_sz)
+        return orig_sz
 
     def _read_frame(self):
         header = readall(self.trans.read, 4)
@@ -213,4 +223,8 @@ cdef class TCySaslClientTransport(CyTransportBase):
     def close(self):
         self.trans.close()
         self.sasl = None
+        self.encode_decided = False
+        self.encode = False
+        self.__rbuf.clean()
+        self.__wbuf.clean()
 


### PR DESCRIPTION
The SASL client transports had several bugs. The Cython `TCySaslClientTransport` (the default export on CPython) was unusable: `c_read` did not return the byte count so the first `read()` raised immediately, it ignored the buffer read offset when draining leftover data, and it could `memcpy` past the end of the data when a frame came up short. The pure Python `TSaslClientTransport` returned short reads when a thrift message spanned multiple SASL frames, while the protocol layer relies on `read(sz)` returning exactly `sz` bytes.

Both implementations now loop over frames until the requested size is satisfied, tolerate SASL libraries returning `str` or `None` during negotiation, return `b''` for empty payloads, reset their state on `close()`, and use `ALREADY_OPEN` for the double-open error. Also removed a leftover debug return value in `c_flush`.

Added `tests/test_sasl.py` covering both implementations with fake SASL objects: negotiation, cross-frame reads, QOP wrapping, EOF and reopen. These are the first tests for the SASL transports.