### PR TITLE
Support path-like objects in load

### DIFF
--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -6,6 +6,7 @@ import socket
 import sys
 import threading
 import time
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -18,6 +19,8 @@ from thriftpy2.contrib.aio.transport import (TAsyncBufferedTransportFactory,
 from thriftpy2.rpc import make_aio_client, make_aio_server
 from thriftpy2.thrift import TApplicationException
 from thriftpy2.transport import TTransportException
+
+TEST_DIR = Path(__file__).parent
 
 
 if sys.platform == "win32":
@@ -265,14 +268,14 @@ class SSLServerMixin:
         return {
             'host': 'localhost',
             'port': cls.port,
-            'certfile': "ssl/server.pem",
-            'keyfile': "ssl/server.key",
+            'certfile': TEST_DIR / "ssl/server.pem",
+            'keyfile': TEST_DIR / "ssl/server.key",
         }
 
     @classmethod
     def client_kwargs(cls):
         kw = cls.server_kwargs()
-        kw['cafile'] = "ssl/CA.pem"
+        kw['cafile'] = TEST_DIR / "ssl/CA.pem"
         return kw
 
     async def client_with_url(self, timeout: int = 3000):

--- a/tests/test_all_protocols_binary_field.py
+++ b/tests/test_all_protocols_binary_field.py
@@ -2,6 +2,7 @@ import sys
 import time
 import traceback
 from multiprocessing import Process
+from pathlib import Path
 
 import pytest
 
@@ -21,6 +22,8 @@ from thriftpy2.protocol import TBinaryProtocolFactory
 from thriftpy2.rpc import make_server as make_rpc_server, \
     make_client as make_rpc_client
 from thriftpy2.transport import TBufferedTransportFactory, TCyMemoryBuffer
+
+TEST_DIR = Path(__file__).parent
 
 
 if sys.platform == "win32":
@@ -64,7 +67,7 @@ def recursive_vars(obj):
 @pytest.mark.parametrize('proto_factory', protocols)
 def test_protocols(proto_factory, binary, tlist, server_func):
     test_thrift = thriftpy2.load(
-        "apache_json_test.thrift",
+        TEST_DIR / "apache_json_test.thrift",
         module_name="test_thrift"
     )
     Foo = test_thrift.Foo
@@ -161,7 +164,7 @@ def test_protocols(proto_factory, binary, tlist, server_func):
 @pytest.mark.parametrize('proto_factory', protocols)
 def test_exceptions(server_func, proto_factory):
     test_thrift = thriftpy2.load(
-        "apache_json_test.thrift",
+        TEST_DIR / "apache_json_test.thrift",
         module_name="test_thrift"
     )
     TestException = test_thrift.TestException
@@ -201,7 +204,7 @@ def test_exceptions(server_func, proto_factory):
 @pytest.mark.parametrize('proto_factory', protocols)
 def test_complex_binary(proto_factory):
 
-    spec = thriftpy2.load("bin_test.thrift", module_name="bin_thrift")
+    spec = thriftpy2.load(TEST_DIR / "bin_test.thrift", module_name="bin_thrift")
     bin_test_obj = spec.BinTest(
         tbinary=b'\x01\x0f\xffa binary string\x0f\xee',
         str2bin={

--- a/tests/test_apache_json.py
+++ b/tests/test_apache_json.py
@@ -3,6 +3,7 @@ import sys
 import time
 from io import BytesIO
 from multiprocessing import Process
+from pathlib import Path
 
 import pytest
 
@@ -16,6 +17,8 @@ from thriftpy2.rpc import make_server as make_rpc_server, \
 from thriftpy2.thrift import TProcessor, TType
 from thriftpy2.transport import TMemoryBuffer
 from thriftpy2.transport.buffered import TBufferedTransportFactory
+
+TEST_DIR = Path(__file__).parent
 
 
 def recursive_vars(obj):
@@ -35,7 +38,7 @@ def recursive_vars(obj):
 
 def test_thrift_transport():
     test_thrift = thriftpy2.load(
-        "apache_json_test.thrift",
+        TEST_DIR / "apache_json_test.thrift",
         module_name="test_thrift"
     )
     Test = test_thrift.Test
@@ -149,7 +152,7 @@ def test_streaming_parse_backslash_string():
                                          (make_http_server, make_http_client)])
 def test_client(server_func):
     test_thrift = thriftpy2.load(
-        "apache_json_test.thrift",
+        TEST_DIR / "apache_json_test.thrift",
         module_name="test_thrift"
     )
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,34 +1,37 @@
 import linecache
+from pathlib import Path
 
 import pytest
 
 import thriftpy2
 from thriftpy2.thrift import parse_spec, TType
 
+TEST_DIR = Path(__file__).parent
+
 
 def test_obj_equalcheck():
-    ab = thriftpy2.load("addressbook.thrift")
-    ab2 = thriftpy2.load("addressbook.thrift")
+    ab = thriftpy2.load(TEST_DIR / "addressbook.thrift")
+    ab2 = thriftpy2.load(TEST_DIR / "addressbook.thrift")
 
     assert ab.Person(name="hello") == ab2.Person(name="hello")
 
 
 def test_exc_equalcheck():
-    ab = thriftpy2.load("addressbook.thrift")
+    ab = thriftpy2.load(TEST_DIR / "addressbook.thrift")
 
     assert ab.PersonNotExistsError("exc") != ab.PersonNotExistsError("exc")
 
 
 def test_cls_equalcheck():
-    ab = thriftpy2.load("addressbook.thrift")
-    ab2 = thriftpy2.load("addressbook.thrift")
+    ab = thriftpy2.load(TEST_DIR / "addressbook.thrift")
+    ab2 = thriftpy2.load(TEST_DIR / "addressbook.thrift")
 
     assert ab.Person == ab2.Person
 
 
 def test_isinstancecheck():
-    ab = thriftpy2.load("addressbook.thrift")
-    ab2 = thriftpy2.load("addressbook.thrift")
+    ab = thriftpy2.load(TEST_DIR / "addressbook.thrift")
+    ab2 = thriftpy2.load(TEST_DIR / "addressbook.thrift")
 
     assert isinstance(ab.Person(), ab2.Person)
     assert isinstance(ab.Person(name="hello"), ab2.Person)
@@ -37,7 +40,7 @@ def test_isinstancecheck():
 
 
 def test_hashable():
-    ab = thriftpy2.load("addressbook.thrift")
+    ab = thriftpy2.load(TEST_DIR / "addressbook.thrift")
 
     # exception is hashable
     hash(ab.PersonNotExistsError("test error"))
@@ -48,13 +51,13 @@ def test_hashable():
 
 
 def test_default_value():
-    ab = thriftpy2.load("addressbook.thrift")
+    ab = thriftpy2.load(TEST_DIR / "addressbook.thrift")
 
     assert ab.PhoneNumber().type == ab.PhoneType.MOBILE
 
 
 def test_parse_spec():
-    ab = thriftpy2.load("addressbook.thrift")
+    ab = thriftpy2.load(TEST_DIR / "addressbook.thrift")
 
     cases = [
         ((TType.I32, None), "I32"),
@@ -71,5 +74,5 @@ def test_parse_spec():
 
 
 def test_init_func():
-    thriftpy2.load("addressbook.thrift")
+    thriftpy2.load(TEST_DIR / "addressbook.thrift")
     assert linecache.getline('<generated PhoneNumber.__init__>', 1) != ''

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,5 +1,11 @@
+from pathlib import Path
+
 import thriftpy2
+
+TEST_DIR = Path(__file__).parent
+
 thriftpy2.install_import_hook()
+thriftpy2.load(TEST_DIR / "const.thrift", module_name="const_thrift")
 
 import const_thrift as const    # noqa
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,8 +1,13 @@
+from pathlib import Path
+
 import thriftpy2
 
 from thriftpy2.utils import serialize, deserialize
 
+TEST_DIR = Path(__file__).parent
+
 thriftpy2.install_import_hook()
+thriftpy2.load(TEST_DIR / "container.thrift", module_name="container_thrift")
 
 import container_thrift as container  # noqa
 

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -1,15 +1,17 @@
 import pickle
 import sys
+from pathlib import Path
 
 import pytest
 
 import thriftpy2
 
 PICKLED_BYTES = b"\x80\x02caddressbook_thrift\nPerson\nq\x00)\x81q\x01}q\x02(X\x04\x00\x00\x00nameq\x03X\x03\x00\x00\x00Bobq\x04X\x06\x00\x00\x00phonesq\x05NX\n\x00\x00\x00created_atq\x06Nub."  # noqa
+TEST_DIR = Path(__file__).parent
 
 
 def test_import_hook():
-    ab_1 = thriftpy2.load("addressbook.thrift")
+    ab_1 = thriftpy2.load(TEST_DIR / "addressbook.thrift")
     print("Load file succeed.")
     assert ab_1.DEFAULT_LIST_SIZE == 10
 
@@ -26,8 +28,8 @@ def test_import_hook():
 
 
 def test_load():
-    ab_1 = thriftpy2.load("addressbook.thrift")
-    ab_2 = thriftpy2.load("addressbook.thrift",
+    ab_1 = thriftpy2.load(TEST_DIR / "addressbook.thrift")
+    ab_2 = thriftpy2.load(TEST_DIR / "addressbook.thrift",
                           module_name="addressbook_thrift")
 
     assert ab_1.__name__ == "addressbook"
@@ -57,9 +59,9 @@ def test_load_module():
 
 def test_duplicate_loads():
     # multiple loads with same module_name returns the same module
-    ab_1 = thriftpy2.load("addressbook.thrift",
+    ab_1 = thriftpy2.load(TEST_DIR / "addressbook.thrift",
                           module_name="addressbook_thrift")
-    ab_2 = thriftpy2.load("./addressbook.thrift",
+    ab_2 = thriftpy2.load(TEST_DIR / "./addressbook.thrift",
                           module_name="addressbook_thrift")
     assert ab_1 == ab_2
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,9 +1,15 @@
+from pathlib import Path
+
 from thriftpy2 import load
 from thriftpy2.thrift import TPayload, TException, TType
 
 import thriftpy2
 
+TEST_DIR = Path(__file__).parent
+
 thriftpy2.install_import_hook()
+load(TEST_DIR / "addressbook.thrift", module_name="addressbook_thrift")
+load(TEST_DIR / "storm.thrift", module_name="storm_thrift")
 
 import addressbook as ab  # noqa
 import addressbook_thrift as ab_tt  # noqa
@@ -62,8 +68,8 @@ def test_load_service():
 
 
 def test_load_include():
-    b = load("base.thrift")
-    g = load("parent.thrift")
+    b = load(TEST_DIR / "base.thrift")
+    g = load(TEST_DIR / "parent.thrift")
 
     ts = g.Greet.thrift_spec
     assert (ts[1][2].thrift_spec == b.Hello.thrift_spec and

--- a/tests/test_oneway.py
+++ b/tests/test_oneway.py
@@ -1,11 +1,14 @@
 import sys
 import time
+from pathlib import Path
 
 import pytest
 
 import multiprocessing
 import thriftpy2
 from thriftpy2.rpc import make_client, make_server
+
+TEST_DIR = Path(__file__).parent
 
 
 if sys.platform == "win32":
@@ -21,7 +24,7 @@ class Dispatcher(object):
 
 class TestOneway(object):
 
-    oneway_thrift = thriftpy2.load("oneway.thrift")
+    oneway_thrift = thriftpy2.load(TEST_DIR / "oneway.thrift")
 
     def setup_class(self):
         ctx = multiprocessing.get_context("fork")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,6 @@
 import sys
 import threading
+from pathlib import Path
 
 import pytest
 
@@ -7,13 +8,15 @@ from thriftpy2.thrift import TType
 from thriftpy2.parser import load, load_fp
 from thriftpy2.parser.exc import ThriftParserError, ThriftGrammarError
 
+TEST_DIR = Path(__file__).parent
+
 
 def test_comments():
-    load('parser-cases/comments.thrift')
+    load(TEST_DIR / 'parser-cases/comments.thrift')
 
 
 def test_constants():
-    thrift = load('parser-cases/constants.thrift')
+    thrift = load(TEST_DIR / 'parser-cases/constants.thrift')
     assert thrift.tbool is True
     assert thrift.tboolint is True
     assert thrift.tbyte == 3
@@ -34,8 +37,8 @@ def test_constants():
 
 
 def test_include():
-    thrift = load('parser-cases/include.thrift', include_dirs=[
-        './parser-cases'], module_name='include_thrift')
+    thrift = load(TEST_DIR / 'parser-cases/include.thrift', include_dirs=[
+        str(TEST_DIR / 'parser-cases')], module_name='include_thrift')
     assert thrift.datetime == 1422009523
     assert sys.modules['include_thrift'] is not None
     assert sys.modules['included_thrift'] is not None
@@ -44,7 +47,7 @@ def test_include():
 
 
 def test_include_with_module_name_prefix():
-    load('parser-cases/include.thrift', module_name='parser_cases.include_thrift')
+    load(TEST_DIR / 'parser-cases/include.thrift', module_name='parser_cases.include_thrift')
     assert sys.modules['parser_cases.include_thrift'] is not None
     assert sys.modules['parser_cases.included_thrift'] is not None
     assert sys.modules['parser_cases.include.included_1_thrift'] is not None
@@ -53,12 +56,12 @@ def test_include_with_module_name_prefix():
 
 def test_include_conflict():
     with pytest.raises(ThriftParserError) as excinfo:
-        load('parser-cases/foo.bar.thrift', module_name='foo.bar_thrift')
+        load(TEST_DIR / 'parser-cases/foo.bar.thrift', module_name='foo.bar_thrift')
     assert 'Module name conflict between' in str(excinfo.value)
 
 
 def test_cpp_include():
-    load('parser-cases/cpp_include.thrift')
+    load(TEST_DIR / 'parser-cases/cpp_include.thrift')
 
 
 @pytest.fixture
@@ -80,7 +83,7 @@ def reset_parser_threadlocal():
 def test_load_in_sub_thread(reraise, reset_parser_threadlocal):
     @reraise.wrap
     def f():
-        load('addressbook.thrift')
+        load(TEST_DIR / 'addressbook.thrift')
 
     t = threading.Thread(target=f)
     t.start()
@@ -90,7 +93,7 @@ def test_load_in_sub_thread(reraise, reset_parser_threadlocal):
 def test_load_fp_in_sub_thread(reraise, reset_parser_threadlocal):
     @reraise.wrap
     def f():
-        with open('container.thrift') as fp:
+        with open(TEST_DIR / 'container.thrift') as fp:
             load_fp(fp, 'container_thrift')
 
     t = threading.Thread(target=f)
@@ -99,8 +102,8 @@ def test_load_fp_in_sub_thread(reraise, reset_parser_threadlocal):
 
 
 def test_tutorial():
-    thrift = load('parser-cases/tutorial.thrift', include_dirs=[
-        './parser-cases'])
+    thrift = load(TEST_DIR / 'parser-cases/tutorial.thrift', include_dirs=[
+        str(TEST_DIR / 'parser-cases')])
     assert thrift.INT32CONSTANT == 9853
     assert thrift.MAPCONSTANT == {'hello': 'world', 'goodnight': 'moon'}
     assert thrift.Operation.ADD == 1 and thrift.Operation.SUBTRACT == 2 \
@@ -114,26 +117,26 @@ def test_tutorial():
 
 def test_e_type_error():
     with pytest.raises(ThriftParserError) as excinfo:
-        load('parser-cases/e_type_error_0.thrift')
+        load(TEST_DIR / 'parser-cases/e_type_error_0.thrift')
     assert 'Type error' in str(excinfo.value)
 
     with pytest.raises(ThriftParserError) as excinfo:
-        load('parser-cases/e_type_error_1.thrift')
+        load(TEST_DIR / 'parser-cases/e_type_error_1.thrift')
     assert 'Type error' in str(excinfo.value)
 
     with pytest.raises(ThriftParserError) as excinfo:
-        load('parser-cases/e_type_error_2.thrift')
+        load(TEST_DIR / 'parser-cases/e_type_error_2.thrift')
     assert 'Type error' in str(excinfo.value)
 
 
 def test_value_ref():
-    thrift = load('parser-cases/value_ref.thrift')
+    thrift = load(TEST_DIR / 'parser-cases/value_ref.thrift')
     assert thrift.container == {'key': [1, 2, 3]}
     assert thrift.lst == [39, 899, 123]
 
 
 def test_type_ref():
-    thrift = load('parser-cases/type_ref.thrift')
+    thrift = load(TEST_DIR / 'parser-cases/type_ref.thrift')
     assert thrift.jerry == thrift.type_ref_shared.Writer(
         name='jerry', age=26, country=thrift.type_ref_shared.Country.US)
     assert thrift.book == thrift.type_ref_shared.Book(name='Hello World',
@@ -142,21 +145,21 @@ def test_type_ref():
 
 def test_e_value_ref():
     with pytest.raises(ThriftParserError) as excinfo:
-        load('parser-cases/e_value_ref_0.thrift')
+        load(TEST_DIR / 'parser-cases/e_value_ref_0.thrift')
     assert excinfo.value
 
     with pytest.raises(ThriftParserError) as excinfo:
-        load('parser-cases/e_value_ref_1.thrift')
+        load(TEST_DIR / 'parser-cases/e_value_ref_1.thrift')
     assert str(excinfo.value) == ('Couldn\'t find a named value in enum Lang '
                                   'for value 3')
     with pytest.raises(ThriftParserError) as excinfo:
-        load('parser-cases/e_value_ref_2.thrift')
+        load(TEST_DIR / 'parser-cases/e_value_ref_2.thrift')
     assert str(excinfo.value) == \
         'No enum value or constant found named \'Cookbook\''
 
 
 def test_enums():
-    thrift = load('parser-cases/enums.thrift')
+    thrift = load(TEST_DIR / 'parser-cases/enums.thrift')
     assert thrift.Lang.C == 0
     assert thrift.Lang.Go == 1
     assert thrift.Lang.Java == 2
@@ -173,7 +176,7 @@ def test_enums():
 
 
 def test_structs():
-    thrift = load('parser-cases/structs.thrift')
+    thrift = load(TEST_DIR / 'parser-cases/structs.thrift')
     assert thrift.Person.thrift_spec == {
         1: (TType.STRING, 'name', False),
         2: (TType.STRING, 'address', False)
@@ -214,18 +217,18 @@ def test_structs():
 
 def test_e_structs():
     with pytest.raises(ThriftParserError) as excinfo:
-        load('parser-cases/e_structs_0.thrift')
+        load(TEST_DIR / 'parser-cases/e_structs_0.thrift')
     assert str(excinfo.value) == \
         'Field \'name\' was required to create constant for type \'User\''
 
     with pytest.raises(ThriftParserError) as excinfo:
-        load('parser-cases/e_structs_1.thrift')
+        load(TEST_DIR / 'parser-cases/e_structs_1.thrift')
     assert str(excinfo.value) == \
         'No field named \'avatar\' was found in struct of type \'User\''
 
 
 def test_service():
-    thrift = load('parser-cases/service.thrift')
+    thrift = load(TEST_DIR / 'parser-cases/service.thrift')
     assert thrift.EmailService.thrift_services == ['ping', 'send', 'receive', 'empty']
     assert thrift.EmailService.ping_args.thrift_spec == {}
     assert thrift.EmailService.ping_args.default_spec == []
@@ -260,63 +263,64 @@ def test_service():
 
 
 def test_service_extends():
-    thrift = load('parser-cases/service_extends.thrift')
+    thrift = load(TEST_DIR / 'parser-cases/service_extends.thrift')
     assert thrift.PingService.thrift_services == ['ping', 'getStruct']
 
 
 def test_e_service_extends():
     with pytest.raises(ThriftParserError) as excinfo:
-        load('parser-cases/e_service_extends_0.thrift')
+        load(TEST_DIR / 'parser-cases/e_service_extends_0.thrift')
     assert 'Can\'t find service' in str(excinfo.value)
 
 
 def test_e_dead_include():
     with pytest.raises(ThriftParserError) as excinfo:
-        load('parser-cases/e_dead_include_0.thrift')
+        load(TEST_DIR / 'parser-cases/e_dead_include_0.thrift')
     assert 'Dead including' in str(excinfo.value)
 
 
 def test_e_grammar_error_at_eof():
     with pytest.raises(ThriftGrammarError) as excinfo:
-        load('parser-cases/e_grammar_error_at_eof.thrift')
-    assert str(excinfo.value) == "Grammar error at EOF of the file 'parser-cases/e_grammar_error_at_eof.thrift'"
+        load(TEST_DIR / 'parser-cases/e_grammar_error_at_eof.thrift')
+    thrift_file = TEST_DIR / 'parser-cases/e_grammar_error_at_eof.thrift'
+    assert str(excinfo.value) == "Grammar error at EOF of the file '{}'".format(thrift_file)
 
 
 def test_e_use_thrift_reserved_keywords():
     with pytest.raises(ThriftParserError) as excinfo:
-        load('parser-cases/e_use_thrift_reserved_keywords.thrift')
+        load(TEST_DIR / 'parser-cases/e_use_thrift_reserved_keywords.thrift')
     assert 'Cannot use reserved language keyword' in str(excinfo.value)
 
 
 def test_e_duplicate_field_id_or_name():
     with pytest.raises(ThriftGrammarError) as excinfo:
-        load('parser-cases/e_duplicate_field_id.thrift')
+        load(TEST_DIR / 'parser-cases/e_duplicate_field_id.thrift')
     assert 'field identifier/name has already been used' in str(excinfo.value)
     with pytest.raises(ThriftGrammarError) as excinfo:
-        load('parser-cases/e_duplicate_field_name.thrift')
+        load(TEST_DIR / 'parser-cases/e_duplicate_field_name.thrift')
     assert 'field identifier/name has already been used' in str(excinfo.value)
 
 
 def test_e_duplicate_struct_exception_service():
     with pytest.raises(ThriftGrammarError) as excinfo:
-        load('parser-cases/e_duplicate_struct.thrift')
+        load(TEST_DIR / 'parser-cases/e_duplicate_struct.thrift')
     assert 'type is already defined in' in str(excinfo.value)
     with pytest.raises(ThriftGrammarError) as excinfo:
-        load('parser-cases/e_duplicate_exception.thrift')
+        load(TEST_DIR / 'parser-cases/e_duplicate_exception.thrift')
     assert 'type is already defined in' in str(excinfo.value)
     with pytest.raises(ThriftGrammarError) as excinfo:
-        load('parser-cases/e_duplicate_service.thrift')
+        load(TEST_DIR / 'parser-cases/e_duplicate_service.thrift')
     assert 'type is already defined in' in str(excinfo.value)
 
 
 def test_e_duplicate_function():
     with pytest.raises(ThriftGrammarError) as excinfo:
-        load('parser-cases/e_duplicate_function.thrift')
+        load(TEST_DIR / 'parser-cases/e_duplicate_function.thrift')
     assert 'function is already defined in' in str(excinfo.value)
 
 
 def test_thrift_meta():
-    thrift = load('parser-cases/tutorial.thrift')
+    thrift = load(TEST_DIR / 'parser-cases/tutorial.thrift')
     meta = thrift.__thrift_meta__
     assert meta['consts'] == [thrift.INT32CONSTANT, thrift.MAPCONSTANT]
     assert meta['enums'] == [thrift.Operation]
@@ -331,7 +335,7 @@ def test_load_fp():
     threadlocal.__dict__.clear()
 
     thrift = None
-    with open('parser-cases/shared.thrift') as thrift_fp:
+    with open(TEST_DIR / 'parser-cases/shared.thrift') as thrift_fp:
         thrift = load_fp(thrift_fp, 'shared_thrift')
     assert thrift.__name__ == 'shared_thrift'
     assert thrift.__thrift_file__ is None
@@ -341,14 +345,14 @@ def test_load_fp():
 
 def test_e_load_fp():
     with pytest.raises(ThriftParserError) as excinfo:
-        with open('parser-cases/tutorial.thrift') as thrift_fp:
+        with open(TEST_DIR / 'parser-cases/tutorial.thrift') as thrift_fp:
             load_fp(thrift_fp, 'tutorial_thrift')
         assert ('Unexpected include statement while loading '
                 'from file like object.') == str(excinfo.value)
 
 
 def test_recursive_union():
-    thrift = load('parser-cases/recursive_union.thrift')
+    thrift = load(TEST_DIR / 'parser-cases/recursive_union.thrift')
     assert thrift.Dynamic.thrift_spec == {
         1: (TType.BOOL, 'boolean', False),
         2: (TType.I64, 'integer', False),
@@ -361,13 +365,13 @@ def test_recursive_union():
 
 
 def test_issue_215():
-    thrift = load('parser-cases/issue_215.thrift')
+    thrift = load(TEST_DIR / 'parser-cases/issue_215.thrift')
     assert thrift.abool is True
     assert thrift.falseValue == 123
 
 
 def test_doubles():
-    thrift = load('parser-cases/doubles.thrift')
+    thrift = load(TEST_DIR / 'parser-cases/doubles.thrift')
     book = thrift.Book()
     assert book.price == 1
     assert isinstance(book.price, float)
@@ -380,7 +384,7 @@ def test_doubles():
 
 
 def test_struct_annotations():
-    thrift = load('parser-cases/annotations.thrift')
+    thrift = load(TEST_DIR / 'parser-cases/annotations.thrift')
     assert thrift.foo.__thrift_annotations__ == {
         'cpp.type': 'DenseFoo',
         'python.type': 'DenseFoo',
@@ -397,7 +401,7 @@ def test_struct_annotations():
 
 
 def test_exception_annotations():
-    thrift = load('parser-cases/annotations.thrift')
+    thrift = load(TEST_DIR / 'parser-cases/annotations.thrift')
     assert thrift.foo_error.__thrift_annotations__ == {'foo': 'bar'}
     assert thrift.foo_error.__thrift_field_annotations__ == {
         'error_code': {'foo': 'bar'},
@@ -405,7 +409,7 @@ def test_exception_annotations():
 
 
 def test_enum_annotations():
-    thrift = load('parser-cases/annotations.thrift')
+    thrift = load(TEST_DIR / 'parser-cases/annotations.thrift')
     assert thrift.weekdays.__thrift_annotations__ == {'foo.bar': 'baz'}
     assert thrift.weekdays.__thrift_item_annotations__ == {
         'SUNDAY': {'weekend': 'yes'},
@@ -414,7 +418,7 @@ def test_enum_annotations():
 
 
 def test_service_annotations():
-    thrift = load('parser-cases/annotations.thrift')
+    thrift = load(TEST_DIR / 'parser-cases/annotations.thrift')
     assert thrift.foo_service.__thrift_annotations__ == {'a.b': 'c'}
     assert thrift.foo_service.__thrift_function_annotations__ == {
         'foo': {'foo': 'bar'},
@@ -422,30 +426,30 @@ def test_service_annotations():
 
 
 def test_union_annotations():
-    thrift = load('parser-cases/annotations.thrift')
+    thrift = load(TEST_DIR / 'parser-cases/annotations.thrift')
     assert thrift.foo_union.__thrift_annotations__ == {'a.b': 'c'}
 
 
 def test_typedef_annotations():
-    thrift = load('parser-cases/annotations.thrift')
+    thrift = load(TEST_DIR / 'parser-cases/annotations.thrift')
     assert thrift.__thrift_typedef_annotations__ == {
         'non_latin_string': {'foo': 'bar'},
     }
 
 
 def test_const_annotations():
-    thrift = load('parser-cases/annotations.thrift')
+    thrift = load(TEST_DIR / 'parser-cases/annotations.thrift')
     assert thrift.__thrift_const_annotations__ == {
         'id': {'name': 'LANG_ID'},
     }
 
 
 def test_annotations_issue_252():
-    load('parser-cases/issue_252.thrift')
+    load(TEST_DIR / 'parser-cases/issue_252.thrift')
 
 
 def test_nest_incomplete_type():
-    thrift = load('parser-cases/nest_incomplete_type.thrift')
+    thrift = load(TEST_DIR / 'parser-cases/nest_incomplete_type.thrift')
     assert thrift.Container.thrift_spec == {
         1: (15, 'field1', (13, (11, (12, thrift.A))), False),
         2: (15, 'field2', (15, (12, thrift.A)), False),
@@ -462,7 +466,7 @@ def test_thrift_in_include_path():
     The fix only replaces the final .thrift file extension suffix.
     """
     thrift = load(
-        'parser-cases/thrift_in_path/parent.thrift',
+        TEST_DIR / 'parser-cases/thrift_in_path/parent.thrift',
         module_name='thrift_in_path_parent_thrift',
     )
     # 'thrift' in the directory path must be preserved as '.thrift.' not '_thrift'
@@ -473,4 +477,4 @@ def test_thrift_in_include_path():
 
 
 def test_issue_121():
-    load('parser-cases/issue_121.thrift')
+    load(TEST_DIR / 'parser-cases/issue_121.thrift')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -38,7 +38,7 @@ def test_constants():
 
 def test_include():
     thrift = load(TEST_DIR / 'parser-cases/include.thrift', include_dirs=[
-        str(TEST_DIR / 'parser-cases')], module_name='include_thrift')
+        TEST_DIR / 'parser-cases'], module_name='include_thrift')
     assert thrift.datetime == 1422009523
     assert sys.modules['include_thrift'] is not None
     assert sys.modules['included_thrift'] is not None

--- a/tests/test_protocol_binary.py
+++ b/tests/test_protocol_binary.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from pathlib import Path
 
 import pytest
 
@@ -8,6 +9,8 @@ from thriftpy2.protocol import binary as proto
 from thriftpy2.thrift import TPayload, TType
 from thriftpy2.utils import hexlify, serialize
 from thriftpy2.transport.memory import TMemoryBuffer
+
+TEST_DIR = Path(__file__).parent
 
 
 class TItem(TPayload):
@@ -231,7 +234,7 @@ def test_string_binary_equivalency():
 
 
 def string_binary_equivalency(proto_factory):
-    container = load("./container.thrift")
+    container = load(TEST_DIR / "container.thrift")
     l_item = container.ListItem()
     l_item.list_string = ['foo', 'bar']
     l_item.list_list_string = [['foo', 'bar']]

--- a/tests/test_recursive_definition.py
+++ b/tests/test_recursive_definition.py
@@ -1,13 +1,17 @@
+from pathlib import Path
+
 from thriftpy2.parser import load
+
+TEST_DIR = Path(__file__).parent
 
 
 def test_recursive_definition():
-    thrift = load('./recursive_definition.thrift')
+    thrift = load(TEST_DIR / "recursive_definition.thrift")
     assert thrift.Bar.thrift_spec == {1: (12, 'test', thrift.Foo, False)}
     assert thrift.Foo.thrift_spec == {
         1: (12, 'test', thrift.Bar, False), 2: (15, 'some_int', 8, False)}
 
 
 def test_const():
-    thrift = load('./recursive_definition.thrift')
+    thrift = load(TEST_DIR / "recursive_definition.thrift")
     assert thrift.SOME_INT == [1, 2, 3]

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -4,6 +4,7 @@ import socket
 import ssl
 import sys
 import time
+from pathlib import Path
 
 import pytest
 
@@ -14,6 +15,8 @@ thriftpy2.install_import_hook()
 from thriftpy2.rpc import client_context, make_server  # noqa
 from thriftpy2.thrift import TApplicationException  # noqa
 from thriftpy2.transport import TTransportException  # noqa
+
+TEST_DIR = Path(__file__).parent
 
 if sys.platform == "win32":
     pytest.skip("requires unix domain socket", allow_module_level=True)
@@ -121,7 +124,7 @@ def ipv6_server(request):
 def ssl_server(request):
     ssl_server = make_server(addressbook.AddressBookService, Dispatcher(),
                              host='localhost', port=SSL_PORT,
-                             certfile="ssl/server.pem")
+                             certfile=TEST_DIR / "ssl/server.pem")
     ps = multiprocessing.Process(target=ssl_server.serve)
     ps.start()
 
@@ -173,8 +176,9 @@ def ssl_client(timeout=3000):
                           host='localhost', port=SSL_PORT,
                           socket_timeout=timeout,
                           connect_timeout=timeout,
-                          cafile="ssl/CA.pem", certfile="ssl/client.crt",
-                          keyfile="ssl/client.key")
+                          cafile=TEST_DIR / "ssl/CA.pem",
+                          certfile=TEST_DIR / "ssl/client.crt",
+                          keyfile=TEST_DIR / "ssl/client.key")
 
 
 def ssl_client_with_url(timeout=3000):
@@ -183,9 +187,9 @@ def ssl_client_with_url(timeout=3000):
                               port=SSL_PORT),
                           socket_timeout=timeout,
                           connect_timeout=timeout,
-                          cafile="ssl/CA.pem",
-                          certfile="ssl/client.crt",
-                          keyfile="ssl/client.key")
+                          cafile=TEST_DIR / "ssl/CA.pem",
+                          certfile=TEST_DIR / "ssl/client.crt",
+                          keyfile=TEST_DIR / "ssl/client.key")
 
 
 def test_clients(ssl_server):

--- a/tests/test_sslsocket.py
+++ b/tests/test_sslsocket.py
@@ -1,10 +1,13 @@
 import ssl
 import threading
+from pathlib import Path
 
 import pytest
 
 from thriftpy2.transport import TTransportException, create_thriftpy_context
 from thriftpy2.transport.sslsocket import TSSLSocket, TSSLServerSocket
+
+TEST_DIR = Path(__file__).parent
 
 
 def _echo_server(sock):
@@ -38,18 +41,19 @@ def _test_socket(server_socket, client_socket):
 
 def test_inet_ssl_socket():
     server_socket = TSSLServerSocket(host="localhost", port=12345,
-                                     certfile="ssl/server.pem")
+                                     certfile=TEST_DIR / "ssl/server.pem")
     client_socket = TSSLSocket(
         host="localhost", port=12345,
-        cafile="ssl/CA.pem",
-        certfile="ssl/client.crt", keyfile="ssl/client.key")
+        cafile=TEST_DIR / "ssl/CA.pem",
+        certfile=TEST_DIR / "ssl/client.crt",
+        keyfile=TEST_DIR / "ssl/client.key")
     _test_socket(server_socket, client_socket)
 
     # without certfile
     server_socket = TSSLServerSocket(host="localhost", port=12345,
-                                     certfile="ssl/server.pem")
+                                     certfile=TEST_DIR / "ssl/server.pem")
     client_socket = TSSLSocket(host="localhost", port=12345,
-                               cafile="ssl/CA.pem")
+                               cafile=TEST_DIR / "ssl/CA.pem")
 
     _test_socket(server_socket, client_socket)
 
@@ -58,13 +62,14 @@ def test_inet_ssl_socket():
                     reason="check hostname not supported")
 def test_ssl_hostname_validate():
     server_socket = TSSLServerSocket(host="localhost", port=12345,
-                                     certfile="ssl/server.pem")
+                                     certfile=TEST_DIR / "ssl/server.pem")
 
     # the ssl cert lock hostname to "localhost"
     client_socket = TSSLSocket(
         host="127.0.0.1", port=12345, socket_timeout=3000,
-        cafile="ssl/CA.pem", certfile="ssl/client.crt",
-        keyfile="ssl/client.key")
+        cafile=TEST_DIR / "ssl/CA.pem",
+        certfile=TEST_DIR / "ssl/client.crt",
+        keyfile=TEST_DIR / "ssl/client.key")
     with pytest.raises((ssl.CertificateError, TTransportException)):
         _test_socket(server_socket, client_socket)
 
@@ -72,21 +77,24 @@ def test_ssl_hostname_validate():
     client_socket = TSSLSocket(
         host="127.0.0.1", port=12345, socket_timeout=3000,
         validate=False,
-        cafile="ssl/CA.pem", certfile="ssl/client.crt",
-        keyfile="ssl/client.key")
+        cafile=TEST_DIR / "ssl/CA.pem",
+        certfile=TEST_DIR / "ssl/client.crt",
+        keyfile=TEST_DIR / "ssl/client.key")
     _test_socket(server_socket, client_socket)
 
 
 def test_persist_ssl_context():
     server_ssl_context = create_thriftpy_context(server_side=True)
-    server_ssl_context.load_cert_chain(certfile="ssl/server.pem")
+    server_ssl_context.load_cert_chain(certfile=TEST_DIR / "ssl/server.pem")
     server_socket = TSSLServerSocket(host="localhost", port=12345,
                                      ssl_context=server_ssl_context)
 
     client_ssl_context = create_thriftpy_context(server_side=False)
-    client_ssl_context.load_verify_locations(cafile="ssl/CA.pem")
-    client_ssl_context.load_cert_chain(certfile="ssl/client.crt",
-                                       keyfile="ssl/client.key")
+    client_ssl_context.load_verify_locations(cafile=TEST_DIR / "ssl/CA.pem")
+    client_ssl_context.load_cert_chain(
+        certfile=TEST_DIR / "ssl/client.crt",
+        keyfile=TEST_DIR / "ssl/client.key",
+    )
     client_socket = TSSLSocket(host="localhost", port=12345,
                                ssl_context=client_ssl_context)
 

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -1,8 +1,12 @@
+from pathlib import Path
+
 from thriftpy2 import load
 from thriftpy2.thrift import TType
 
+TEST_DIR = Path(__file__).parent
+
 
 def test_set():
-    s = load("type.thrift")
+    s = load(TEST_DIR / "type.thrift")
 
     assert s.Set.thrift_spec == {1: (TType.SET, "a_set", TType.STRING, True)}

--- a/thriftpy2/parser/__init__.py
+++ b/thriftpy2/parser/__init__.py
@@ -20,8 +20,8 @@ from ..thrift import TPayloadMeta
 def load(
     path: Union[str, os.PathLike],
     module_name: Optional[str] = None,
-    include_dirs: Optional[List[str]] = None,
-    include_dir: Optional[str] = None,
+    include_dirs: Optional[List[Union[str, os.PathLike]]] = None,
+    include_dir: Optional[Union[str, os.PathLike]] = None,
     encoding: str = 'utf-8',
 ) -> types.ModuleType:
     """Load thrift file as a module.
@@ -34,6 +34,10 @@ def load(
     `include_dirs`.
     """
     path = os.fspath(path)
+    if include_dirs is not None:
+        include_dirs = [os.fspath(d) for d in include_dirs]
+    if include_dir is not None:
+        include_dir = os.fspath(include_dir)
     real_module = bool(module_name)
     thrift = parse(path, module_name, include_dirs=include_dirs,
                    include_dir=include_dir, encoding=encoding)

--- a/thriftpy2/parser/__init__.py
+++ b/thriftpy2/parser/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import os
 import sys
 import types
-from typing import List, Optional, TextIO
+from typing import List, Optional, TextIO, Union
 
 from .parser import parse, parse_fp, threadlocal, _cast
 from .exc import ThriftParserError, ThriftModuleNameConflict
@@ -18,7 +18,7 @@ from ..thrift import TPayloadMeta
 
 
 def load(
-    path: str,
+    path: Union[str, os.PathLike],
     module_name: Optional[str] = None,
     include_dirs: Optional[List[str]] = None,
     include_dir: Optional[str] = None,
@@ -33,6 +33,7 @@ def load(
     instead. If `include_dir` was provided (not None), it will be appended to
     `include_dirs`.
     """
+    path = os.fspath(path)
     real_module = bool(module_name)
     thrift = parse(path, module_name, include_dirs=include_dirs,
                    include_dir=include_dir, encoding=encoding)


### PR DESCRIPTION
- Support path-like objects in `thriftpy2.load`.
- Make tests independent of the current working directory.