### PR TITLE
Remove dead assignment of _read_struct_begin return value

### DIFF
--- a/thriftpy2/protocol/compact.py
+++ b/thriftpy2/protocol/compact.py
@@ -551,7 +551,7 @@ class TCompactProtocol(TProtocolBase):
             self._read_string()
 
         elif ttype == TType.STRUCT:
-            name = self._read_struct_begin()
+            self._read_struct_begin()
             while True:
                 (name, ttype, id) = self._read_field_begin()
                 if ttype == TType.STOP:


### PR DESCRIPTION
`_read_struct_begin()` returns `None` and the assigned name was immediately overwritten in the loop, so the assignment was useless and misleading.