### PR TITLE
Make TPayload hashable with a value-based hash

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,10 +1,9 @@
 import linecache
 from pathlib import Path
 
-import pytest
-
 import thriftpy2
-from thriftpy2.thrift import parse_spec, TType
+from thriftpy2.thrift import parse_spec, TPayload, TType
+from thriftpy2.utils import deserialize, serialize
 
 TEST_DIR = Path(__file__).parent
 
@@ -45,9 +44,47 @@ def test_hashable():
     # exception is hashable
     hash(ab.PersonNotExistsError("test error"))
 
-    # container struct is not hashable
-    with pytest.raises(TypeError):
-        hash(ab.Person(name="Tom"))
+    # struct is hashable
+    hash(ab.Person(name="Tom"))
+
+    # struct with container fields is hashable
+    hash(ab.Person(name="Tom", phones=[ab.PhoneNumber(number="123")]))
+
+
+def test_hash_consistent_with_eq():
+    ab = thriftpy2.load(TEST_DIR / "addressbook.thrift")
+
+    p1 = ab.Person(name="Tom", phones=[ab.PhoneNumber(number="123")])
+    p2 = ab.Person(name="Tom", phones=[ab.PhoneNumber(number="123")])
+    assert p1 == p2
+    assert hash(p1) == hash(p2)
+    assert len({p1, p2}) == 1
+
+    # exceptions still compare and hash by identity
+    e1 = ab.PersonNotExistsError("exc")
+    e2 = ab.PersonNotExistsError("exc")
+    assert len({e1, e2}) == 2
+
+
+def test_struct_as_map_key():
+    class Point(TPayload):
+        thrift_spec = {
+            1: (TType.I32, "x", False),
+            2: (TType.I32, "y", False),
+        }
+        default_spec = [("x", None), ("y", None)]
+
+    class Board(TPayload):
+        thrift_spec = {
+            1: (TType.MAP, "labels",
+                ((TType.STRUCT, Point), TType.STRING), False),
+        }
+        default_spec = [("labels", None)]
+
+    board = Board(labels={Point(x=1, y=2): "start", Point(x=3, y=4): "end"})
+    result = deserialize(Board(), serialize(board))
+    assert result == board
+    assert result.labels[Point(x=1, y=2)] == "start"
 
 
 def test_default_value():

--- a/thriftpy2/thrift.py
+++ b/thriftpy2/thrift.py
@@ -153,9 +153,27 @@ def gen_init(cls: type, thrift_spec: Optional[Dict[int, tuple]] = None,
     return cls
 
 
+def _hash_value(value: Any) -> int:
+    """Hash a field value, freezing mutable containers so that the
+    result is consistent with ``TPayload.__eq__``."""
+    if isinstance(value, dict):
+        return hash(frozenset(
+            (_hash_value(k), _hash_value(v)) for k, v in value.items()))
+    if isinstance(value, (list, tuple)):
+        return hash(tuple(_hash_value(v) for v in value))
+    if isinstance(value, (set, frozenset)):
+        return hash(frozenset(_hash_value(v) for v in value))
+    return hash(value)
+
+
 class TPayload(metaclass=TPayloadMeta):
 
-    __hash__ = None
+    def __hash__(self) -> int:
+        # Consistent with __eq__: equal payloads hash equal, so structs
+        # can be used as thrift map keys or set members.  Note that like
+        # any mutable object used as a key, mutating a payload after it
+        # is put in a dict or set breaks lookups.
+        return hash(self.__class__) ^ _hash_value(self.__dict__)
 
     def read(self, iprot: 'TProtocolBase') -> None:
         iprot.read_struct(self)


### PR DESCRIPTION
Structs and unions are valid thrift map keys, but deserializing such a map raises `TypeError: unhashable type` because `TPayload.__hash__` is set to `None` (see #331).

Simply restoring the default identity hash would reintroduce the inconsistency with the value-based `__eq__` reported in Thriftpy/thriftpy#184. Instead, implement `__hash__` consistent with `__eq__`, recursively freezing container fields so structs containing list, map or set fields are hashable as well. This follows the value semantics used by other Thrift implementations (e.g. Java's generated `equals`/`hashCode`), where map keys with equal field values overwrite each other.

`TException` keeps its identity-based `__hash__`/`__eq__`.

Closes #331.