### PR TITLE
Fix argument mapping for out of order field IDs

### DIFF
--- a/tests/out_of_order_fields.thrift
+++ b/tests/out_of_order_fields.thrift
@@ -1,0 +1,7 @@
+service HelloService {
+    string say_hello(
+        1: required string a,
+        3: required string b,
+        2: required string c,
+    )
+}

--- a/tests/test_out_of_order_fields.py
+++ b/tests/test_out_of_order_fields.py
@@ -1,0 +1,67 @@
+"""Regression tests for out of order field IDs (issue #367).
+
+Arguments must be mapped by IDL declaration order, not by field ID,
+to stay compatible with Apache Thrift generated code.
+"""
+
+import multiprocessing
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+import thriftpy2
+from thriftpy2.rpc import make_client, make_server
+from thriftpy2.thrift import TType, args_to_kwargs
+
+TEST_DIR = Path(__file__).parent
+PORT = 50442
+
+
+def test_args_to_kwargs_declaration_order():
+    spec = {
+        1: (TType.STRING, "a", True),
+        3: (TType.STRING, "b", True),
+        2: (TType.STRING, "c", True),
+    }
+    assert args_to_kwargs(spec, "x", "y", "z") == \
+        {"a": "x", "b": "y", "c": "z"}
+    assert args_to_kwargs(spec, "x", c="z", b="y") == \
+        {"a": "x", "b": "y", "c": "z"}
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="requires fork")
+class TestOutOfOrderFieldsRPC(object):
+
+    hello_thrift = thriftpy2.load(TEST_DIR / "out_of_order_fields.thrift")
+
+    class Dispatcher(object):
+        def say_hello(self, a, b, c):
+            return "%s %s %s" % (a, b, c)
+
+    def setup_class(self):
+        ctx = multiprocessing.get_context("fork")
+        server = make_server(self.hello_thrift.HelloService,
+                             self.Dispatcher(), "127.0.0.1", PORT)
+        self.p = ctx.Process(target=server.serve)
+        self.p.start()
+        time.sleep(1)  # Wait a second for server to start.
+
+    def teardown_class(self):
+        self.p.terminate()
+
+    def test_positional_args(self):
+        client = make_client(self.hello_thrift.HelloService,
+                             "127.0.0.1", PORT)
+        assert client.say_hello("x", "y", "z") == "x y z"
+
+    def test_keyword_args(self):
+        client = make_client(self.hello_thrift.HelloService,
+                             "127.0.0.1", PORT)
+        assert client.say_hello(a="x", b="y", c="z") == "x y z"
+
+    def test_mixed_args(self):
+        client = make_client(self.hello_thrift.HelloService,
+                             "127.0.0.1", PORT)
+        assert client.say_hello("x", c="z", b="y") == "x y z"

--- a/thriftpy2/contrib/aio/processor.py
+++ b/thriftpy2/contrib/aio/processor.py
@@ -19,8 +19,8 @@ class TAsyncProcessor(object):
         await iprot.read_message_end()
         result = getattr(self._service, api + "_result")()
 
-        # convert kwargs to args
-        api_args = [args.thrift_spec[k][1] for k in sorted(args.thrift_spec)]
+        # convert kwargs to args, following the IDL declaration order
+        api_args = [item[1] for item in args.thrift_spec.values()]
 
         async def call():
             f = getattr(self._handler, api)

--- a/thriftpy2/contrib/tracking/__init__.py
+++ b/thriftpy2/contrib/tracking/__init__.py
@@ -188,9 +188,8 @@ class TTrackedProcessor(TProcessor, VersionMixin):
         iprot.read_message_end()
         result = getattr(self._service, api + "_result")()
 
-        # convert kwargs to args
-        api_args = [args.thrift_spec[k][1]
-                    for k in sorted(args.thrift_spec)]
+        # convert kwargs to args, following the IDL declaration order
+        api_args = [item[1] for item in args.thrift_spec.values()]
 
         def call():
             return getattr(self._handler, api)(

--- a/thriftpy2/thrift.py
+++ b/thriftpy2/thrift.py
@@ -18,7 +18,9 @@ if TYPE_CHECKING:
 
 def args_to_kwargs(thrift_spec: Dict[int, tuple], *args: Any,
                    **kwargs: Any) -> Dict[str, Any]:
-    for item, value in zip_longest(sorted(thrift_spec.items()), args):
+    # Positional arguments follow the IDL declaration order (the order of
+    # thrift_spec insertion), matching Apache Thrift generated signatures.
+    for item, value in zip_longest(thrift_spec.items(), args):
         arg_name = item[1][1]
         required = item[1][-1]
         if value is not None:
@@ -303,8 +305,8 @@ class TProcessor(object):
         iprot.read_message_end()
         result = getattr(self._service, api + "_result")()
 
-        # convert kwargs to args
-        api_args = [args.thrift_spec[k][1] for k in sorted(args.thrift_spec)]
+        # convert kwargs to args, following the IDL declaration order
+        api_args = [item[1] for item in args.thrift_spec.values()]
 
         def call():
             f = getattr(self._handler, api)
@@ -394,8 +396,8 @@ class TMultiplexedProcessor(TProcessor):
         iprot.read_message_end()
         result = getattr(proc._service, api + "_result")()
 
-        # convert kwargs to args
-        api_args = [args.thrift_spec[k][1] for k in sorted(args.thrift_spec)]
+        # convert kwargs to args, following the IDL declaration order
+        api_args = [item[1] for item in args.thrift_spec.values()]
 
         def call():
             f = getattr(proc._handler, api)


### PR DESCRIPTION
Fixes #367.

When a function's field IDs don't follow the declaration order, thriftpy2 mapped positional arguments (on the client) and handler arguments (on the server) by field ID order, while Apache Thrift generated code uses declaration order. The two errors cancel out for positional calls between thriftpy2 peers, but keyword calls end up with swapped arguments, and positional calls send mislabeled values on the wire when talking to an Apache Thrift peer.

This changes all argument mapping to follow the declaration order (the insertion order of thrift_spec), matching Apache Thrift. Note this is a behavior change for IDLs with out-of-order field IDs: old and new thriftpy2 peers will disagree on positional argument order, so client and server should be upgraded together.