### PR TITLE
Fix flaky async HTTP server shutdown

### DIFF
--- a/tests/test_aio_http.py
+++ b/tests/test_aio_http.py
@@ -127,13 +127,13 @@ class _TestAsyncHttp:
 
     @classmethod
     def _stop_server(cls):
-        async def stop():
-            await cls.server.close()
-
-        cls._server_loop.call_soon_threadsafe(
-            lambda: asyncio.ensure_future(stop(), loop=cls._server_loop)
+        future = asyncio.run_coroutine_threadsafe(
+            cls.server.close(), cls._server_loop
         )
-        cls._server_loop.call_soon_threadsafe(cls._server_loop.stop)
+        try:
+            future.result(timeout=2)
+        except Exception:
+            pass
         cls._server_thread.join(timeout=2)
 
     async def client(self, timeout=30000):
@@ -251,13 +251,13 @@ class TestAsyncHttpTimeout:
 
     @classmethod
     def _stop_server(cls):
-        async def stop():
-            await cls.server.close()
-
-        cls._server_loop.call_soon_threadsafe(
-            lambda: asyncio.ensure_future(stop(), loop=cls._server_loop)
+        future = asyncio.run_coroutine_threadsafe(
+            cls.server.close(), cls._server_loop
         )
-        cls._server_loop.call_soon_threadsafe(cls._server_loop.stop)
+        try:
+            future.result(timeout=2)
+        except Exception:
+            pass
         cls._server_thread.join(timeout=2)
 
     @pytest.mark.asyncio
@@ -310,13 +310,13 @@ class TestAsyncHttpCustomHeaders:
 
     @classmethod
     def _stop_server(cls):
-        async def stop():
-            await cls.server.close()
-
-        cls._server_loop.call_soon_threadsafe(
-            lambda: asyncio.ensure_future(stop(), loop=cls._server_loop)
+        future = asyncio.run_coroutine_threadsafe(
+            cls.server.close(), cls._server_loop
         )
-        cls._server_loop.call_soon_threadsafe(cls._server_loop.stop)
+        try:
+            future.result(timeout=2)
+        except Exception:
+            pass
         cls._server_thread.join(timeout=2)
 
     @pytest.mark.asyncio

--- a/thriftpy2/contrib/aio/http.py
+++ b/thriftpy2/contrib/aio/http.py
@@ -240,6 +240,7 @@ class TAsyncHttpServer:
         self._app = None
         self._runner = None
         self._site = None
+        self._stop_event = None
 
     async def _handle_request(self, request):
         """Handle incoming HTTP POST request."""
@@ -290,20 +291,29 @@ class TAsyncHttpServer:
         )
         await self._site.start()
 
-        # Keep running until closed
+        # Keep running until close() is called or the task is cancelled.
+        self._stop_event = asyncio.Event()
         try:
-            while True:
-                await asyncio.sleep(3600)
+            await self._stop_event.wait()
         except asyncio.CancelledError:
             pass
+        finally:
+            await self._cleanup()
 
     async def close(self):
         """Close the HTTP server."""
+        if self._stop_event is not None:
+            # serve() is running; signal it to stop and clean up itself.
+            self._stop_event.set()
+        else:
+            await self._cleanup()
+
+    async def _cleanup(self):
         if self._runner:
             await self._runner.cleanup()
-            self._runner = None
-            self._site = None
-            self._app = None
+        self._runner = None
+        self._site = None
+        self._app = None
 
 
 async def make_client(service, host='localhost', port=9090, path='',


### PR DESCRIPTION
The async HTTP server tests fail intermittently on CI with PytestUnhandledThreadExceptionWarning, complaining about "Event loop stopped before Future completed."

The cause is in how the server shuts down. serve() parks itself in a `while True: await asyncio.sleep(3600)` loop that only breaks on CancelledError, but the test teardown never cancels it — it just calls loop.stop(). So when the loop stops, run_until_complete finds its future still pending and raises RuntimeError, which then escapes the daemon server thread. Whether pytest catches that as a warning depends on timing, hence the flakiness.

I gave the server a stop event that close() sets. Now serve() returns on its own and the loop unwinds cleanly, and teardown just awaits close() on the server loop instead of racing stop() against loop.stop(). Also moved the runner cleanup into a finally so it still runs when serve() is cancelled directly.

Ran the file a bunch of times locally with the thread-exception warning promoted to an error; no failures.