### PR TITLE
Reduce basedpyright baseline with low-cost typing fixes

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -54,64 +54,6 @@
                 }
             }
         ],
-        "./thriftpy2/contrib/aio/protocol/binary.py": [
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalCall",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./thriftpy2/contrib/aio/protocol/compact.py": [
             {
                 "code": "reportIncompatibleMethodOverride",
@@ -242,62 +184,6 @@
                 }
             },
             {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalCall",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 14,
@@ -307,30 +193,6 @@
             }
         ],
         "./thriftpy2/contrib/aio/rpc.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportArgumentType",
                 "range": {
@@ -344,14 +206,6 @@
                 "range": {
                     "startColumn": 10,
                     "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 41,
                     "lineCount": 1
                 }
             }
@@ -412,14 +266,6 @@
                 "range": {
                     "startColumn": 30,
                     "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIndexIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 22,
                     "lineCount": 1
                 }
             }
@@ -546,10 +392,26 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 29,
+                    "startColumn": 26,
+                    "endColumn": 74,
+                    "lineCount": 2
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 54,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 53,
+                    "endColumn": 62,
                     "lineCount": 1
                 }
             },
@@ -578,10 +440,10 @@
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 29,
+                    "startColumn": 38,
+                    "endColumn": 47,
                     "lineCount": 1
                 }
             },
@@ -594,10 +456,10 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 44,
+                    "startColumn": 20,
+                    "endColumn": 29,
                     "lineCount": 1
                 }
             },
@@ -666,26 +528,10 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 44,
                     "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 33,
                     "lineCount": 1
                 }
             },
@@ -700,14 +546,6 @@
         ],
         "./thriftpy2/parser/__init__.py": [
             {
-                "code": "reportOptionalCall",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportIndexIssue",
                 "range": {
                     "startColumn": 20,
@@ -736,46 +574,6 @@
                 "range": {
                     "startColumn": 49,
                     "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 38,
                     "lineCount": 1
                 }
             },
@@ -790,46 +588,6 @@
         ],
         "./thriftpy2/parser/parser.py": [
             {
-                "code": "reportOptionalCall",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPossiblyUnboundVariable",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalCall",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 53,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 53,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportIndexIssue",
                 "range": {
                     "startColumn": 7,
@@ -866,70 +624,6 @@
                 "range": {
                     "startColumn": 7,
                     "endColumn": 8,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalCall",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalCall",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalCall",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 54,
                     "lineCount": 1
                 }
             }
@@ -1090,112 +784,6 @@
                 }
             }
         ],
-        "./thriftpy2/protocol/binary.py": [
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalCall",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./thriftpy2/protocol/compact.py": [
             {
                 "code": "reportIncompatibleMethodOverride",
@@ -1206,185 +794,15 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalCall",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
                     "endColumn": 27,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./thriftpy2/protocol/json.py": [
-            {
-                "code": "reportOptionalCall",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 73,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
             }
         ],
         "./thriftpy2/rpc.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportArgumentType",
                 "range": {
@@ -1394,26 +812,10 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 48,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPossiblyUnboundVariable",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 17,
+                    "startColumn": 44,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
             }
@@ -1437,30 +839,6 @@
             }
         ],
         "./thriftpy2/thrift.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportOptionalCall",
                 "range": {
@@ -1590,14 +968,6 @@
                     "endColumn": 34,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
             }
         ],
         "./thriftpy2/transport/sasl/__init__.py": [
@@ -1696,14 +1066,6 @@
                 "range": {
                     "startColumn": 18,
                     "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIndexIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 22,
                     "lineCount": 1
                 }
             },

--- a/thriftpy2/contrib/aio/protocol/binary.py
+++ b/thriftpy2/contrib/aio/protocol/binary.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from thriftpy2.thrift import TType
 
 from thriftpy2.protocol.exc import TProtocolException
@@ -66,7 +68,7 @@ async def read_map_begin(inbuf):
     return k_type, v_type, sz
 
 
-async def read_val(inbuf, ttype, spec=None, decode_response=True,
+async def read_val(inbuf, ttype, spec: Any = None, decode_response=True,
                    strict_decode=False):
     if ttype == TType.BOOL:
         return bool(unpack_i8(await inbuf.read(1)))

--- a/thriftpy2/contrib/aio/protocol/compact.py
+++ b/thriftpy2/contrib/aio/protocol/compact.py
@@ -1,4 +1,5 @@
 from struct import unpack
+from typing import Any
 
 from thriftpy2.protocol.exc import TProtocolException
 from thriftpy2.thrift import TException, TType
@@ -182,7 +183,7 @@ class TAsyncCompactProtocol(TCompactProtocol,  # Inherit all of the writing
             self._read_field_end()
         self._read_struct_end()
 
-    async def _read_val(self, ttype, spec=None):
+    async def _read_val(self, ttype, spec: Any = None):
         if ttype == TType.BOOL:
             return await self._read_bool()
 

--- a/thriftpy2/contrib/aio/rpc.py
+++ b/thriftpy2/contrib/aio/rpc.py
@@ -1,7 +1,7 @@
 import socket
 import ssl
 import types
-import urllib
+import urllib.parse
 import warnings
 from typing import Any, Optional
 

--- a/thriftpy2/contrib/aio/socket.py
+++ b/thriftpy2/contrib/aio/socket.py
@@ -5,6 +5,7 @@ import socket
 import ssl
 import struct
 import sys
+from typing import Optional
 if sys.version_info >= (3, 7, 0):
     from asyncio import get_running_loop
 else:
@@ -26,7 +27,8 @@ class TAsyncSocket(object):
 
     def __init__(self, host=None, port=None, unix_socket=None,
                  sock=None, socket_family=socket.AF_INET,
-                 socket_timeout=3000, connect_timeout=None,
+                 socket_timeout: Optional[int] = 3000,
+                 connect_timeout: Optional[int] = None,
                  ssl_context=None, validate=True,
                  cafile=None, capath=None, certfile=None, keyfile=None,
                  ciphers=DEFAULT_CIPHERS):
@@ -214,7 +216,8 @@ class TAsyncServerSocket(object):
     """Socket implementation for server side."""
 
     def __init__(self, host=None, port=None, unix_socket=None,
-                 socket_family=socket.AF_INET, client_timeout=3000,
+                 socket_family=socket.AF_INET,
+                 client_timeout: Optional[int] = 3000,
                  backlog=128, ssl_context=None, certfile=None, keyfile=None,
                  ciphers=RESTRICTED_SERVER_CIPHERS):
         """Initialize a TServerSocket
@@ -283,7 +286,7 @@ class TAsyncServerSocket(object):
             try:
                 _sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
             except socket.error as err:
-                if err[0] in (errno.ENOPROTOOPT, errno.EINVAL):
+                if err.errno in (errno.ENOPROTOOPT, errno.EINVAL):
                     pass
                 else:
                     raise

--- a/thriftpy2/http.py
+++ b/thriftpy2/http.py
@@ -35,7 +35,7 @@ import socket
 import ssl
 import sys
 import types
-import urllib
+import urllib.parse
 from contextlib import contextmanager
 from io import BytesIO
 from typing import (BinaryIO, Callable, Dict, Generator, Optional,

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -8,6 +8,7 @@ import itertools
 import os
 import threading
 import types
+from typing import Any
 from urllib.parse import urlparse
 from urllib.request import urlopen
 
@@ -187,7 +188,7 @@ def p_const_map_item(p):
 
 def p_const_ref(p):
     '''const_ref : IDENTIFIER'''
-    child = threadlocal.thrift_stack[-1]
+    child = father = threadlocal.thrift_stack[-1]
     for name in p[1].split('.'):
         father = child
         child = getattr(child, name, None)
@@ -609,7 +610,7 @@ def parse(path, module_name=None, include_dirs=None, include_dir=None,
     if lexer is None:
         lexer = lex.lex()
     if parser is None:
-        parser = yacc.yacc(debug=False, write_tables=0)
+        parser = yacc.yacc(debug=False, write_tables=False)
 
     if include_dirs is not None:
         threadlocal.include_dirs_ = include_dirs
@@ -696,7 +697,7 @@ def parse_fp(source, module_name, lexer=None, parser=None, enable_cache=True):
     if lexer is None:
         lexer = lex.lex()
     if parser is None:
-        parser = yacc.yacc(debug=False, write_tables=0)
+        parser = yacc.yacc(debug=False, write_tables=False)
 
     data = source.read()
 
@@ -737,7 +738,7 @@ def _parse_seq(p):
         p[0] = []
 
 
-def _cast(t, linno=0):  # noqa
+def _cast(t: Any, linno: int = 0) -> Any:  # noqa
     if isinstance(t, int) and t < 0:
         return _lazy_cast_const(t, linno)
     if t == TType.BOOL:
@@ -1021,7 +1022,7 @@ def _make_service(name, funcs, extends, annotations=None, lineno=None):
         if len(func) > 6 and func[6]:
             function_annotations[func_name] = _annotations_to_dict(func[6])
     if extends is not None and hasattr(extends, 'thrift_services'):
-        thrift_services.extend(extends.thrift_services)
+        thrift_services.extend(getattr(extends, 'thrift_services'))
     setattr(cls, 'thrift_services', thrift_services)
     setattr(cls, '__thrift_function_linenos__', function_linenos)
     setattr(cls, '__thrift_annotations__', _annotations_to_dict(annotations))

--- a/thriftpy2/protocol/binary.py
+++ b/thriftpy2/protocol/binary.py
@@ -1,4 +1,5 @@
 import struct
+from typing import Any
 
 from ..thrift import TType
 
@@ -92,7 +93,7 @@ def write_map_begin(outbuf, ktype, vtype, size):
     outbuf.write(pack_i8(ktype) + pack_i8(vtype) + pack_i32(size))
 
 
-def write_val(outbuf, ttype, val, spec=None):
+def write_val(outbuf, ttype, val, spec: Any = None):
     if ttype == TType.BOOL:
         if val:
             outbuf.write(pack_i8(1))
@@ -213,7 +214,7 @@ def read_map_begin(inbuf):
     return k_type, v_type, sz
 
 
-def read_val(inbuf, ttype, spec=None, decode_response=True,
+def read_val(inbuf, ttype, spec: Any = None, decode_response=True,
              strict_decode=False):
     if ttype == TType.BOOL:
         return bool(unpack_i8(inbuf.read(1)))

--- a/thriftpy2/protocol/compact.py
+++ b/thriftpy2/protocol/compact.py
@@ -1,6 +1,7 @@
 import array
 import sys
 from struct import pack, unpack
+from typing import Any
 
 
 from ..thrift import TException, TType
@@ -276,7 +277,7 @@ class TCompactProtocol(TProtocolBase):
             self._read_field_end()
         self._read_struct_end()
 
-    def _read_val(self, ttype, spec=None):
+    def _read_val(self, ttype, spec: Any = None):
         if ttype == TType.BOOL:
             return self._read_bool()
 
@@ -464,7 +465,7 @@ class TCompactProtocol(TProtocolBase):
         self._write_field_stop()
         self._write_struct_end()
 
-    def _write_val(self, ttype, val, spec=None):
+    def _write_val(self, ttype, val, spec: Any = None):
 
         if ttype == TType.BOOL:
             self._write_bool(val)

--- a/thriftpy2/protocol/json.py
+++ b/thriftpy2/protocol/json.py
@@ -2,6 +2,7 @@ import base64
 import json
 import struct
 import sys
+from typing import Any, Dict
 from warnings import warn
 
 
@@ -19,7 +20,7 @@ def encode_binary(data):
     return base64.b64encode(data).decode('ascii')
 
 
-def json_value(ttype, val, spec=None):
+def json_value(ttype, val, spec: Any = None):
     TTYPE_TO_JSONFUNC_MAP = {
         TType.BYTE: (int, (val,)),
         TType.I16: (int, (val,)),
@@ -44,7 +45,7 @@ def json_value(ttype, val, spec=None):
     )
 
 
-def obj_value(ttype, val, spec=None):
+def obj_value(ttype, val, spec: Any = None):
     # Special case: since `spec` needs to get called if TType is STRUCT,
     # if we initialize inside `TTYPE_TO_OBJFUNC_MAP` it will get called
     # everytime the function gets called and incur in exception as
@@ -182,7 +183,7 @@ class TJSONProtocol(TProtocolBase):
 
     def __init__(self, trans):
         TProtocolBase.__init__(self, trans)
-        self._meta = {"version": VERSION}
+        self._meta: Dict[str, Any] = {"version": VERSION}
         self._data = None
 
     def _write_len(self, x):

--- a/thriftpy2/rpc.py
+++ b/thriftpy2/rpc.py
@@ -2,7 +2,7 @@ import contextlib
 import socket
 import ssl
 import types
-import urllib
+import urllib.parse
 import warnings
 from typing import Generator, Optional
 
@@ -153,8 +153,8 @@ def client_context(service: types.ModuleType, host: str = "localhost",
         raise ValueError("Either host/port or unix_socket"
                          " or url must be provided.")
 
+    transport = trans_factory.get_transport(client_socket)
     try:
-        transport = trans_factory.get_transport(client_socket)
         protocol = proto_factory.get_protocol(transport)
         transport.open()
         yield TClient(service, protocol)

--- a/thriftpy2/thrift.py
+++ b/thriftpy2/thrift.py
@@ -9,8 +9,8 @@ import functools
 import linecache
 import types
 from itertools import zip_longest
-from typing import (Any, Callable, Dict, List, Optional, Tuple, Type,
-                    TYPE_CHECKING)
+from typing import (Any, Callable, ClassVar, Dict, List, Optional, Tuple,
+                    Type, TYPE_CHECKING)
 
 if TYPE_CHECKING:
     from thriftpy2.protocol.base import TProtocolBase
@@ -135,6 +135,11 @@ class TMessageType(object):
 
 class TPayloadMeta(type):
 
+    # Declared for type checkers: generated payload classes carry these
+    # class attributes (assigned by gen_init / the parser at runtime).
+    thrift_spec: Dict[int, tuple]
+    default_spec: List[Tuple[str, Any]]
+
     def __new__(cls, name: str, bases: Tuple[type, ...],
                 attrs: Dict[str, Any]) -> 'TPayloadMeta':
         if "default_spec" in attrs:
@@ -167,6 +172,9 @@ def _hash_value(value: Any) -> int:
 
 
 class TPayload(metaclass=TPayloadMeta):
+
+    thrift_spec: ClassVar[Dict[int, tuple]]
+    default_spec: ClassVar[List[Tuple[str, Any]]]
 
     def __hash__(self) -> int:
         # Consistent with __eq__: equal payloads hash equal, so structs

--- a/thriftpy2/tornado.py
+++ b/thriftpy2/tornado.py
@@ -16,7 +16,7 @@
 import logging
 import socket
 import struct
-import urllib
+import urllib.parse
 import warnings
 from contextlib import contextmanager
 from datetime import timedelta

--- a/thriftpy2/transport/socket.py
+++ b/thriftpy2/transport/socket.py
@@ -203,7 +203,7 @@ class TServerSocket(object):
             try:
                 _sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
             except socket.error as err:
-                if err[0] in (errno.ENOPROTOOPT, errno.EINVAL):
+                if err.errno in (errno.ENOPROTOOPT, errno.EINVAL):
                     pass
                 else:
                     raise


### PR DESCRIPTION
This shrinks the basedpyright baseline from 211 to 132 errors, mostly with annotation-only changes: annotate the `spec=None` parameters in the binary/compact/json protocols, declare `thrift_spec` / `default_spec` on `TPayload` and `TPayloadMeta`, annotate `_cast` in the parser, use `import urllib.parse` instead of relying on `import urllib` side effects, and a few other small fixes.

Two behavior-affecting fixes are included as well. `client_context` in rpc.py now creates the transport before entering the try block, so a failure in `get_transport` no longer raises a NameError from the finally clause. The SO_REUSEPORT error handling in the socket transports used Python 2 style `err[0]` indexing, which raises TypeError on Python 3; it now checks `err.errno`.

The remaining baseline entries need structural work (async subclasses overriding sync base methods, transports not inheriting `TTransportBase`) and can be tackled separately.