### PR TITLE
fix: allow enum default value declared after its use

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -478,3 +478,24 @@ def test_thrift_in_include_path():
 
 def test_issue_121():
     load(TEST_DIR / 'parser-cases/issue_121.thrift')
+
+
+def test_enum_default_value_declared_after_use(tmp_path):
+    """Regression: an enum used as a field default before it is declared.
+
+    Forward references are already supported for field *types*; a default
+    value referring to a not-yet-parsed enum member used to raise
+    ThriftParserError("Can't find name 'Type.AA'").
+    """
+    path = tmp_path / 'forward_enum_default.thrift'
+    path.write_text(
+        'struct A {\n'
+        '    1: Type t = Type.AA\n'
+        '}\n'
+        'enum Type {\n'
+        '    AA = 1\n'
+        '    BB = 2\n'
+        '}\n'
+    )
+    thrift = load(path)
+    assert thrift.A().t == 1

--- a/thriftpy2/parser/__init__.py
+++ b/thriftpy2/parser/__init__.py
@@ -12,9 +12,9 @@ import sys
 import types
 from typing import List, Optional, TextIO, Union
 
-from .parser import parse, parse_fp, threadlocal, _cast
+from .parser import parse, parse_fp, threadlocal, _cast, _get_ttype
 from .exc import ThriftParserError, ThriftModuleNameConflict
-from ..thrift import TPayloadMeta
+from ..thrift import TPayloadMeta, TType, gen_init
 
 
 def load(
@@ -70,11 +70,16 @@ def fill_incomplete_ttype(tmodule, definition):
     """
     # construct incomplete types' thrift_spec
     if isinstance(definition, tuple):
+        # construct a constant reference that was not defined yet when it was
+        # used, e.g. an enum member used as a default value before the enum
+        # itself is declared
+        if definition[0] == 'UNKNOWN_CONST_REF':
+            return get_const_value(tmodule, definition[1], definition[2])
         # construct const value
         if definition[0] == 'UNKNOWN_CONST':
             ttype = get_definition(
                 tmodule, threadlocal.incomplete_type[definition[1]][0], definition[3])
-            return _cast(ttype)(definition[2])
+            return _cast(ttype)(fill_incomplete_ttype(tmodule, definition[2]))
         # construct incomplete alias type
         elif definition[1] in threadlocal.incomplete_type:
             return (
@@ -101,6 +106,15 @@ def fill_incomplete_ttype(tmodule, definition):
             setattr(definition, name, fill_incomplete_ttype(definition, attr))
     # if type is a struct, search it if there are incomplete types
     elif isinstance(definition, TPayloadMeta):
+        default_spec = getattr(definition, 'default_spec', None)
+        if default_spec:
+            new_default_spec = [
+                (name, fill_incomplete_ttype(tmodule, value))
+                for name, value in default_spec
+            ]
+            if new_default_spec != default_spec:
+                gen_init(definition, None, new_default_spec)
+                definition.default_spec = new_default_spec
         for index, value in definition.thrift_spec.items():
             # if the ttype of the field is a single type and it is incompleted
             if value[0] in threadlocal.incomplete_type:
@@ -160,6 +174,20 @@ def fill_incomplete_ttype(tmodule, definition):
             for index, value in attr.thrift_spec.items():
                 attr.thrift_spec[index] = fill_incomplete_ttype(tmodule, value)
     return definition
+
+
+def get_const_value(thrift, name, lineno):
+    """Resolve a constant/enum-member reference deferred during parsing."""
+    child = father = thrift
+    for part in name.split('.'):
+        father = child
+        child = getattr(child, part, None)
+        if child is None:
+            raise ThriftParserError('Can\'t find name %r at line %d'
+                                    % (name, lineno))
+    if _get_ttype(child) is None or _get_ttype(father) == TType.I32:
+        return child
+    raise ThriftParserError('No enum value or constant found named %r' % name)
 
 
 def get_definition(thrift, name, lineno):

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -193,8 +193,12 @@ def p_const_ref(p):
         father = child
         child = getattr(child, name, None)
         if child is None:
-            raise ThriftParserError('Can\'t find name %r at line %d'
-                                    % (p[1], p.lineno(1)))
+            # The referenced name may simply not have been parsed yet, e.g. an
+            # enum member used as a default value before the enum is defined.
+            # Defer it like other forward references; it is resolved by
+            # fill_incomplete_ttype() once the whole file has been parsed.
+            p[0] = ('UNKNOWN_CONST_REF', p[1], p.lineno(1))
+            return
 
     if _get_ttype(child) is None or _get_ttype(father) == TType.I32:
         # child is a constant or enum value


### PR DESCRIPTION
Closes #205

A field default that references an enum member defined *later* in the same thrift file raised `ThriftParserError: Can't find name 'Type.AA'`, even though forward references already work for field types (via `incomplete_type` + the `fill_incomplete_ttype` second pass).

`p_const_ref` now defers an unresolved name as an `UNKNOWN_CONST_REF` marker instead of raising immediately, and `fill_incomplete_ttype` resolves it — regenerating the struct's `default_spec`/`__init__` — once the whole file has been parsed. A genuinely undefined name still raises, just from the second pass.

New `test_enum_default_value_declared_after_use` fails with the reported error without the fix and passes with it; `tests/test_parser.py` is otherwise unchanged (41 passed, same 2 pre-existing thread-test errors before and after).
