### PR TITLE
fix: resolve include statements in load_fp when source is a real file

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,4 @@
+import io
 import sys
 import threading
 from pathlib import Path
@@ -333,17 +334,26 @@ def test_load_fp():
     with open(TEST_DIR / 'parser-cases/shared.thrift') as thrift_fp:
         thrift = load_fp(thrift_fp, 'shared_thrift')
     assert thrift.__name__ == 'shared_thrift'
-    assert thrift.__thrift_file__ is None
     assert thrift.__thrift_meta__['structs'] == [thrift.SharedStruct]
     assert thrift.__thrift_meta__['services'] == [thrift.SharedService]
 
 
+def test_load_fp_with_include():
+    from thriftpy2.parser import parser as _parser
+    _parser._thrift_cache.clear()
+
+    with open(TEST_DIR / 'parser-cases/tutorial.thrift') as thrift_fp:
+        thrift = load_fp(thrift_fp, 'tutorial_thrift')
+    assert thrift.__thrift_meta__['includes'] == [thrift.shared]
+    assert thrift.shared.SharedStruct is not None
+
+
 def test_e_load_fp():
+    content = (TEST_DIR / 'parser-cases/tutorial.thrift').read_text()
     with pytest.raises(ThriftParserError) as excinfo:
-        with open(TEST_DIR / 'parser-cases/tutorial.thrift') as thrift_fp:
-            load_fp(thrift_fp, 'tutorial_thrift')
-        assert ('Unexpected include statement while loading '
-                'from file like object.') == str(excinfo.value)
+        load_fp(io.StringIO(content), 'tutorial_stringio_thrift')
+    assert ('Unexpected include statement while loading '
+            'from file like object.') == str(excinfo.value)
 
 
 def test_recursive_union():

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -726,8 +726,15 @@ def parse_fp(source, module_name, lexer=None, parser=None, enable_cache=True,
 
         data = source.read()
 
+        # When `source` is a real file object its `name` gives us the path the
+        # thrift text came from, so `include` statements can be resolved
+        # relative to it just like in `parse`.
+        source_path = getattr(source, 'name', None)
+        if not isinstance(source_path, str) or not os.path.isfile(source_path):
+            source_path = None
+
         thrift = types.ModuleType(module_name)
-        setattr(thrift, '__thrift_file__', None)
+        setattr(thrift, '__thrift_file__', source_path)
         _parse_data(data, thrift, context, lexer, parser,
                     is_root=_context is None)
 


### PR DESCRIPTION
Closes #285

`parse_fp` always set `__thrift_file__` to `None`, so `p_include` had no base directory to resolve against and rejected any thrift file with an `include` statement — even when the file-like object was an ordinary `open()` file whose path is known. When `source` has a usable `.name` pointing at an existing file, it is now used as `__thrift_file__` so includes resolve relative to it, exactly as `parse()` does; non-file objects (`StringIO`, sockets) keep the existing error.

`test_load_fp_with_include` fails on master with the reported `ThriftParserError` and passes with the fix; `test_e_load_fp` now covers the still-unresolvable case via `StringIO`.
