### PR TITLE
fix(parser): allow include statements in load_fp

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -338,6 +338,24 @@ def test_load_fp():
     assert thrift.__thrift_meta__['services'] == [thrift.SharedService]
 
 
+def test_load_fp_with_include(monkeypatch):
+    from thriftpy2.parser import parser as _parser
+    _parser._thrift_cache.clear()
+
+    monkeypatch.chdir(TEST_DIR / 'parser-cases')
+    try:
+        with open('include.thrift') as thrift_fp:
+            thrift = load_fp(thrift_fp, 'include_fp_thrift')
+
+        assert thrift.__thrift_file__ is None
+        assert thrift.datetime == 1422009523
+        assert [t.__name__ for t in thrift.__thrift_meta__['includes']] == \
+            ['included', 'included_1']
+    finally:
+        # the includes were cached under paths relative to this directory
+        _parser._thrift_cache.clear()
+
+
 def test_e_load_fp():
     with pytest.raises(ThriftParserError) as excinfo:
         with open(TEST_DIR / 'parser-cases/tutorial.thrift') as thrift_fp:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import threading
 from pathlib import Path
@@ -338,22 +339,105 @@ def test_load_fp():
     assert thrift.__thrift_meta__['services'] == [thrift.SharedService]
 
 
-def test_load_fp_with_include(monkeypatch):
+def test_load_fp_with_include():
     from thriftpy2.parser import parser as _parser
     _parser._thrift_cache.clear()
 
-    monkeypatch.chdir(TEST_DIR / 'parser-cases')
     try:
-        with open('include.thrift') as thrift_fp:
-            thrift = load_fp(thrift_fp, 'include_fp_thrift')
+        with open(TEST_DIR / 'parser-cases' / 'include.thrift') as thrift_fp:
+            thrift = load_fp(thrift_fp, 'include_fp_thrift',
+                             include_dirs=[TEST_DIR / 'parser-cases'])
 
         assert thrift.__thrift_file__ is None
         assert thrift.datetime == 1422009523
         assert [t.__name__ for t in thrift.__thrift_meta__['includes']] == \
             ['included', 'included_1']
     finally:
-        # the includes were cached under paths relative to this directory
+        # the includes were cached under names derived from the include dir
         _parser._thrift_cache.clear()
+
+
+def test_load_fp_include_same_basename_no_collision(tmp_path):
+    # including `a/t.thrift` and `b/t.thrift` from two fp-loaded roots must
+    # not collapse onto the same `t_thrift` module
+    from thriftpy2.parser import parser as _parser
+    _parser._thrift_cache.clear()
+    added_modules = []
+
+    try:
+        (tmp_path / 'a').mkdir()
+        (tmp_path / 'b').mkdir()
+        (tmp_path / 'a' / 't.thrift').write_text('struct A { 1: string x }')
+        (tmp_path / 'b' / 't.thrift').write_text('struct B { 1: string y }')
+        (tmp_path / 'root_a.thrift').write_text(
+            'include "a/t.thrift"\nstruct RootA { 1: t.A a }')
+        (tmp_path / 'root_b.thrift').write_text(
+            'include "b/t.thrift"\nstruct RootB { 1: t.B b }')
+
+        with open(tmp_path / 'root_a.thrift') as fp:
+            thrift_a = load_fp(fp, 'root_a_fp_thrift', include_dirs=[tmp_path])
+        with open(tmp_path / 'root_b.thrift') as fp:
+            thrift_b = load_fp(fp, 'root_b_fp_thrift', include_dirs=[tmp_path])
+        added_modules.extend(['root_a_fp_thrift', 'root_b_fp_thrift',
+                              'a.t_thrift', 'b.t_thrift'])
+
+        assert thrift_a.t.A is not thrift_b.t.B
+        assert thrift_a.t.__thrift_file__.endswith(os.path.join('a', 't.thrift'))
+        assert thrift_b.t.__thrift_file__.endswith(os.path.join('b', 't.thrift'))
+    finally:
+        _parser._thrift_cache.clear()
+        for mod in added_modules:
+            sys.modules.pop(mod, None)
+
+
+def test_load_fp_include_child_matches_load(tmp_path):
+    # the same included file yields the same classes whether the root came
+    # from load() or load_fp()
+    from thriftpy2.parser import parser as _parser
+    _parser._thrift_cache.clear()
+    added_modules = []
+
+    try:
+        (tmp_path / 't.thrift').write_text('struct A { 1: string x }')
+        (tmp_path / 'root.thrift').write_text(
+            'include "t.thrift"\nstruct Root { 1: t.A a }')
+
+        with open(tmp_path / 'root.thrift') as fp:
+            fp_thrift = load_fp(fp, 'root_fp_thrift', include_dirs=[tmp_path])
+        file_thrift = load(str(tmp_path / 'root.thrift'))
+        added_modules.extend(['root_fp_thrift', 't_thrift'])
+
+        assert fp_thrift.t.A is file_thrift.t.A
+    finally:
+        _parser._thrift_cache.clear()
+        for mod in added_modules:
+            sys.modules.pop(mod, None)
+
+
+def test_load_fp_include_child_picklable(tmp_path):
+    # structs from files included by an fp-loaded root are registered in
+    # sys.modules, so they can be pickled
+    import pickle
+    from thriftpy2.parser import parser as _parser
+    _parser._thrift_cache.clear()
+    added_modules = []
+
+    try:
+        (tmp_path / 't.thrift').write_text('struct A { 1: string x }')
+        (tmp_path / 'root.thrift').write_text(
+            'include "t.thrift"\nstruct Root { 1: t.A a }')
+
+        with open(tmp_path / 'root.thrift') as fp:
+            thrift = load_fp(fp, 'root_pickle_fp_thrift',
+                             include_dirs=[tmp_path])
+        added_modules.extend(['root_pickle_fp_thrift', 't_thrift'])
+
+        obj = thrift.t.A(x='hello')
+        assert pickle.loads(pickle.dumps(obj)).x == 'hello'
+    finally:
+        _parser._thrift_cache.clear()
+        for mod in added_modules:
+            sys.modules.pop(mod, None)
 
 
 def test_e_load_fp():

--- a/thriftpy2/parser/__init__.py
+++ b/thriftpy2/parser/__init__.py
@@ -17,6 +17,28 @@ from .exc import ThriftModuleNameConflict
 from .exc import ThriftParserError  # noqa: F401, re-exported for compat
 
 
+def _register_include_modules(thrift: types.ModuleType) -> None:
+    """Register a thrift module's included children in ``sys.modules``,
+    recursively, so structs defined in included files are importable (and
+    therefore picklable). Mirrors what :func:`load` has always done for
+    file-loaded modules.
+    """
+    include_thrifts = thrift.__thrift_meta__["includes"][:]
+    while include_thrifts:
+        include_thrift = include_thrifts.pop()
+        registered_thrift = sys.modules.get(include_thrift.__thrift_module_name__)
+        if registered_thrift is None:
+            sys.modules[include_thrift.__thrift_module_name__] = include_thrift
+            if hasattr(include_thrift, "__thrift_meta__"):
+                include_thrifts.extend(
+                    include_thrift.__thrift_meta__["includes"][:])
+        elif registered_thrift.__thrift_file__ != include_thrift.__thrift_file__:
+            raise ThriftModuleNameConflict(
+                'Module name conflict between "%s" and "%s"' %
+                (registered_thrift.__thrift_file__, include_thrift.__thrift_file__)
+            )
+
+
 def load(
     path: Union[str, os.PathLike],
     module_name: Optional[str] = None,
@@ -46,29 +68,36 @@ def load(
     # add sub modules to sys.modules recursively
     if real_module:
         sys.modules[module_name] = thrift
-        include_thrifts = thrift.__thrift_meta__["includes"][:]
-        while include_thrifts:
-            include_thrift = include_thrifts.pop()
-            registered_thrift = sys.modules.get(include_thrift.__thrift_module_name__)
-            if registered_thrift is None:
-                sys.modules[include_thrift.__thrift_module_name__] = include_thrift
-                if hasattr(include_thrift, "__thrift_meta__"):
-                    include_thrifts.extend(
-                        include_thrift.__thrift_meta__["includes"][:])
-            else:
-                if registered_thrift.__thrift_file__ != include_thrift.__thrift_file__:
-                    raise ThriftModuleNameConflict(
-                        'Module name conflict between "%s" and "%s"' %
-                        (registered_thrift.__thrift_file__, include_thrift.__thrift_file__)
-                    )
+        _register_include_modules(thrift)
     return thrift
 
 
-def load_fp(source: TextIO, module_name: str) -> types.ModuleType:
+def load_fp(source: TextIO, module_name: str,
+            include_dirs: Optional[List[Union[str, os.PathLike]]] = None,
+            include_dir: Optional[Union[str, os.PathLike]] = None
+            ) -> types.ModuleType:
     """Load thrift file like object as a module.
+
+    :param include_dirs: directories to find thrift files while processing
+                         the `include` directive, by default: ['.']. A module
+                         loaded from a file-like object has no path of its
+                         own, so this is the only place its includes are
+                         resolved from; pass the directory holding the thrift
+                         files instead of changing the working directory.
+    :param include_dir: directory to find child thrift files. Note this keyword
+                        parameter will be deprecated in the future, it exists
+                        for compatible reason. If it's provided (not `None`),
+                        it will be appended to `include_dirs`.
     """
-    thrift = parse_fp(source, module_name)
+    if include_dirs is not None:
+        include_dirs = [os.fspath(d) for d in include_dirs]
+    if include_dir is not None:
+        include_dir = os.fspath(include_dir)
+    thrift = parse_fp(source, module_name, include_dirs=include_dirs,
+                      include_dir=include_dir)
     sys.modules[module_name] = thrift
+    # register included children as well, so their structs are picklable
+    _register_include_modules(thrift)
     return thrift
 
 

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -63,20 +63,27 @@ def p_header_unit(p):
 def p_include(p):
     '''include : INCLUDE LITERAL'''
     thrift = p.parser.context.thrift_stack[-1]
+    # A module parsed from a file-like object has no path of its own, so
+    # includes are resolved against `include_dirs` only (default: ['.']).
     if thrift.__thrift_file__ is None:
-        raise ThriftParserError('Unexpected include statement while loading '
-                                'from file like object.')
-    replace_include_dirs = [os.path.dirname(thrift.__thrift_file__)] \
-        + p.parser.context.include_dirs
+        base_dir = None
+        replace_include_dirs = list(p.parser.context.include_dirs)
+    else:
+        base_dir = os.path.dirname(thrift.__thrift_file__)
+        replace_include_dirs = [base_dir] + p.parser.context.include_dirs
     for include_dir in replace_include_dirs:
         path = os.path.join(include_dir, p[2])
         if os.path.exists(path):
-            thrift_file_name_module = os.path.basename(thrift.__thrift_file__)
-            if thrift_file_name_module.endswith(".thrift"):
-                thrift_file_name_module = thrift_file_name_module[:-7] + "_thrift"
-            module_prefix = str(thrift.__name__)[:-len(thrift_file_name_module)] if thrift.__name__.endswith(thrift_file_name_module) else ""
+            if base_dir is None:
+                module_prefix = ""
+                child_rel_path = os.path.basename(path)
+            else:
+                thrift_file_name_module = os.path.basename(thrift.__thrift_file__)
+                if thrift_file_name_module.endswith(".thrift"):
+                    thrift_file_name_module = thrift_file_name_module[:-7] + "_thrift"
+                module_prefix = str(thrift.__name__)[:-len(thrift_file_name_module)] if thrift.__name__.endswith(thrift_file_name_module) else ""
 
-            child_rel_path = os.path.relpath(str(path), os.path.dirname(thrift.__thrift_file__))
+                child_rel_path = os.path.relpath(str(path), base_dir)
             child_module_name = str(child_rel_path).replace(os.sep, ".")
             if child_module_name.endswith(".thrift"):
                 child_module_name = child_module_name[:-7] + "_thrift"

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -65,20 +65,27 @@ def p_include(p):
     thrift = p.parser.context.thrift_stack[-1]
     # A module parsed from a file-like object has no path of its own, so
     # includes are resolved against `include_dirs` only (default: ['.']).
-    if thrift.__thrift_file__ is None:
+    # (Bound to a local so type checkers can narrow the Optional[str].)
+    thrift_file = thrift.__thrift_file__
+    if thrift_file is None:
         base_dir = None
         replace_include_dirs = list(p.parser.context.include_dirs)
     else:
-        base_dir = os.path.dirname(thrift.__thrift_file__)
+        base_dir = os.path.dirname(thrift_file)
         replace_include_dirs = [base_dir] + p.parser.context.include_dirs
     for include_dir in replace_include_dirs:
         path = os.path.join(include_dir, p[2])
         if os.path.exists(path):
             if base_dir is None:
+                # Anchor the child module name at the include dir the child
+                # was found in, so that including e.g. `a/t.thrift` and
+                # `b/t.thrift` from two different roots yields distinct
+                # module names (`a.t_thrift`, `b.t_thrift`) instead of both
+                # collapsing onto the bare basename `t_thrift`.
                 module_prefix = ""
-                child_rel_path = os.path.basename(path)
+                child_rel_path = os.path.relpath(path, include_dir)
             else:
-                thrift_file_name_module = os.path.basename(thrift.__thrift_file__)
+                thrift_file_name_module = os.path.basename(thrift_file)
                 if thrift_file_name_module.endswith(".thrift"):
                     thrift_file_name_module = thrift_file_name_module[:-7] + "_thrift"
                 module_prefix = str(thrift.__name__)[:-len(thrift_file_name_module)] if thrift.__name__.endswith(thrift_file_name_module) else ""
@@ -701,7 +708,7 @@ def parse(path, module_name=None, include_dirs=None, include_dir=None,
 
 
 def parse_fp(source, module_name, lexer=None, parser=None, enable_cache=True,
-             _context=None):
+             include_dirs=None, include_dir=None, _context=None):
     """Parse a file-like object to thrift module object, e.g.::
 
         >>> from thriftpy2.parser.parser import parse_fp
@@ -716,6 +723,15 @@ def parse_fp(source, module_name, lexer=None, parser=None, enable_cache=True,
     :param parser: ply parser to use, if not provided, `parse` will new one.
     :param enable_cache: if this is set to be `True`, parsed module will be
                          cached by `module_name`, this is enabled by default.
+    :param include_dirs: directories to find thrift files while processing
+                         the `include` directive, by default: ['.']. A module
+                         parsed from a file-like object has no path of its
+                         own, so this is the only place its includes are
+                         resolved from.
+    :param include_dir: directory to find child thrift files. Note this keyword
+                        parameter will be deprecated in the future, it exists
+                        for compatible reason. If it's provided (not `None`),
+                        it will be appended to `include_dirs`.
     """
     context = _context if _context is not None else ParseContext()
 
@@ -730,6 +746,11 @@ def parse_fp(source, module_name, lexer=None, parser=None, enable_cache=True,
     with _parse_lock:
         if enable_cache and module_name in _thrift_cache:
             return _thrift_cache[module_name]
+
+        if include_dirs is not None:
+            context.include_dirs = include_dirs
+        if include_dir is not None:
+            context.include_dirs.append(include_dir)
 
         data = source.read()
 


### PR DESCRIPTION
Closes #285

`load_fp`/`parse_fp` rejected any thrift source containing an `include`, so opening a file and passing it to `load_fp` raised `Unexpected include statement while loading from file like object.` even when the included files were resolvable.

A module parsed from a file-like object has no path of its own, so `p_include` can't derive a base directory from `__thrift_file__`; it now falls back to the parse context's `include_dirs` (default `['.']`) and names the child module from the included file's basename. The file-backed path is unchanged.

`tests/test_parser.py::test_load_fp_with_include` fails with the reported error without the parser change and passes with it.
