### PR TITLE
Fix some type errors

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -58,14 +58,6 @@
             {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
-                    "startColumn": 6,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
                     "startColumn": 14,
                     "endColumn": 24,
                     "lineCount": 1
@@ -544,48 +536,6 @@
                 }
             }
         ],
-        "./thriftpy2/parser/parser.py": [
-            {
-                "code": "reportIndexIssue",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 8,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIndexIssue",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 8,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIndexIssue",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 8,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIndexIssue",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 8,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIndexIssue",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 8,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./thriftpy2/protocol/__init__.py": [
             {
                 "code": "reportAttributeAccessIssue",
@@ -750,50 +700,6 @@
                     "endColumn": 26,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./thriftpy2/rpc.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./thriftpy2/server.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
             }
         ],
         "./thriftpy2/thrift.py": [
@@ -930,14 +836,6 @@
         ],
         "./thriftpy2/transport/sasl/__init__.py": [
             {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 13,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 41,
@@ -982,72 +880,6 @@
                 "range": {
                     "startColumn": 60,
                     "endColumn": 68,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./thriftpy2/transport/socket.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 36,
                     "lineCount": 1
                 }
             }

--- a/thriftpy2/parser/parser.py
+++ b/thriftpy2/parser/parser.py
@@ -942,6 +942,7 @@ def _cast(t: Any, linno: int = 0) -> Any:  # noqa
         return _cast_string
     if t == TType.BINARY:
         return _cast_binary
+    assert not isinstance(t, int), "unsupported primitive type: %s" % t
     if t[0] == TType.LIST:
         return _cast_list(t)
     if t[0] == TType.SET:

--- a/thriftpy2/protocol/compact.py
+++ b/thriftpy2/protocol/compact.py
@@ -360,9 +360,9 @@ class TCompactProtocol(TProtocolBase):
             self._write_i16(fid)
         self._last_fid = fid
 
-    def write_message_begin(self, name, type, seqid):
+    def write_message_begin(self, name, ttype, seqid):
         self._write_ubyte(self.PROTOCOL_ID)
-        self._write_ubyte(self.VERSION | (type << self.TYPE_SHIFT_AMOUNT))
+        self._write_ubyte(self.VERSION | (ttype << self.TYPE_SHIFT_AMOUNT))
         write_varint(self.trans, seqid)
         self._write_string(name)
 

--- a/thriftpy2/transport/sasl/__init__.py
+++ b/thriftpy2/transport/sasl/__init__.py
@@ -105,8 +105,8 @@ class TSaslClientTransport(TTransportBase):
             payload = b""
         return status, payload
 
-    def write(self, data):
-        self.__wbuf.write(data)
+    def write(self, buf):
+        self.__wbuf.write(buf)
 
     def flush(self):
         buffer = self.__wbuf.getvalue()

--- a/thriftpy2/transport/socket.py
+++ b/thriftpy2/transport/socket.py
@@ -4,12 +4,12 @@ import socket
 import struct
 import sys
 
-from . import TTransportException
+from .base import TTransportBase, TTransportException
 
 MAC_OR_BSD = sys.platform == 'darwin' or sys.platform.startswith('freebsd')
 
 
-class TSocket(object):
+class TSocket(TTransportBase):
     """Socket implementation for client side."""
 
     def __init__(self, host=None, port=None, unix_socket=None,
@@ -84,17 +84,19 @@ class TSocket(object):
 
     def open(self):
         self._init_sock()
+        sock = self.sock
+        assert sock is not None
 
         addr = self.unix_socket or (self.host, self.port)
 
         try:
             if self.connect_timeout:
-                self.sock.settimeout(self.connect_timeout)
+                sock.settimeout(self.connect_timeout)
 
-            self.sock.connect(addr)
+            sock.connect(addr)
 
             if self.socket_timeout:
-                self.sock.settimeout(self.socket_timeout)
+                sock.settimeout(self.socket_timeout)
 
         except (socket.error, OSError):
             self.close()
@@ -103,9 +105,11 @@ class TSocket(object):
                 message="Could not connect to %s" % str(addr))
 
     def read(self, sz):
+        sock = self.sock
+        assert sock is not None
         while True:
             try:
-                buff = self.sock.recv(sz)
+                buff = sock.recv(sz)
             except socket.error as e:
                 if e.errno == errno.EINTR:
                     continue
@@ -116,7 +120,7 @@ class TSocket(object):
                     # in lib/cpp/src/transport/TSocket.cpp.
                     self.close()
                     # Trigger the check to raise the END_OF_FILE exception.
-                    buff = ''
+                    buff = b''
                     break
                 else:
                     raise
@@ -128,8 +132,10 @@ class TSocket(object):
                                       message='TSocket read 0 bytes')
         return buff
 
-    def write(self, buff):
-        self.sock.sendall(buff)
+    def write(self, buf):
+        sock = self.sock
+        assert sock is not None
+        sock.sendall(buf)
 
     def flush(self):
         pass
@@ -183,6 +189,7 @@ class TServerSocket(object):
         self.socket_family = socket_family
         self.client_timeout = client_timeout / 1000 if client_timeout else None
         self.backlog = backlog
+        self.sock = None
 
     def _init_sock(self):
         if self.unix_socket:
@@ -212,13 +219,17 @@ class TServerSocket(object):
 
     def listen(self):
         self._init_sock()
+        sock = self.sock
+        assert sock is not None
 
         addr = self.unix_socket or (self.host, self.port)
-        self.sock.bind(addr)
-        self.sock.listen(self.backlog)
+        sock.bind(addr)
+        sock.listen(self.backlog)
 
     def accept(self):
-        client, _ = self.sock.accept()
+        sock = self.sock
+        assert sock is not None
+        client, _ = sock.accept()
         if self.client_timeout:
             client.settimeout(self.client_timeout)
         return TSocket(sock=client)


### PR DESCRIPTION
Fix some type errors, such as socket transport inheritance, override parameter names, and unsupported primitive parser types.