### PR TITLE
Fix setuptools warnings when building distributions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
     "setuptools>=68",
     "cython>=0.28.4,<4",
-    "tomli; python_version<'3.11'"
 ]
 
 [project]
@@ -26,16 +25,14 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.14",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[wheel]
-universal = 1
-
 [flake8]
 filename = *.py, *.pyx
 max-line-length = 100

--- a/setup.py
+++ b/setup.py
@@ -2,19 +2,9 @@
 
 import sys
 import platform
-if sys.version_info < (3, 11):
-    import tomli as tomllib
-else:
-    import tomllib
 
-from os.path import join, dirname
 from setuptools import setup, find_packages, Extension
 
-
-with open(join(dirname(__file__), 'pyproject.toml'), "rb") as f:
-    meta = tomllib.load(f)
-    install_requires = meta["project"]["dependencies"]
-    dev_requires = meta["project"]["optional-dependencies"]["dev"]
 
 ext_modules = []
 
@@ -52,11 +42,6 @@ if not PYPY:
 setup(
       packages=find_packages(exclude=['benchmark', 'docs', 'tests']),
       zip_safe=False,
-      long_description=open("README.rst").read(),
-      install_requires=install_requires,
-      extras_require={
-          "dev": dev_requires
-      },
       ext_modules=ext_modules,
       include_package_data=True,
       package_data={"thriftpy2": ["py.typed"]},

--- a/thriftpy2/__init__.py
+++ b/thriftpy2/__init__.py
@@ -3,7 +3,7 @@ import sys
 from .hook import install_import_hook, remove_import_hook
 from .parser import load, load_module, load_fp
 
-__version__ = '0.7.0a1'
+__version__ = '0.7.0'
 __python__ = sys.version_info
 __all__ = ["install_import_hook", "remove_import_hook", "load", "load_module",
            "load_fp"]


### PR DESCRIPTION
Cleans up the setuptools warnings from `pyproject-build`: setup.py no longer re-reads pyproject.toml to pass `install_requires`/`extras_require`/`long_description` (setuptools overwrites them anyway, so `tomli` is no longer needed to build), and the Python 2 era `[wheel] universal = 1` in setup.cfg is gone. Also drops duplicate 3.11/3.12 classifiers and fixes `__version__`, which the 0.7.0 bump missed.

The remaining `project.license` warnings need setuptools>=77, hence Python>=3.9, so that migration is left for whenever 3.7/3.8 are dropped.