### PR TITLE
Raise EOF from TCyMemoryBuffer.c_read on insufficient data

### DIFF
--- a/tests/test_protocol_cybinary.py
+++ b/tests/test_protocol_cybinary.py
@@ -93,6 +93,18 @@ def test_read_i32():
     assert 1234567890 == proto.read_val(b, TType.I32)
 
 
+def test_read_truncated_memory_buffer():
+    from thriftpy2.transport import TTransportException
+
+    b = TCyMemoryBuffer(b"I\x96")
+    with pytest.raises(TTransportException):
+        proto.read_val(b, TType.I32)
+
+    b = TCyMemoryBuffer(b"\x0b\x00\x01\x00\x00\x00\x05hel")
+    with pytest.raises(TTransportException):
+        proto.TCyBinaryProtocol(b).read_struct(TItem())
+
+
 def test_write_i64():
     b = TCyMemoryBuffer()
     proto.write_val(b, TType.I64, 1234567890123456789)

--- a/thriftpy2/transport/memory/cymemory.pyx
+++ b/thriftpy2/transport/memory/cymemory.pyx
@@ -9,6 +9,8 @@ from thriftpy2.transport.cybase cimport (
 )
 from cpython cimport bool, PyObject_GetBuffer, PyBuffer_Release, PyBUF_ANY_CONTIGUOUS, PyBUF_SIMPLE
 
+from .. import TTransportException
+
 
 cdef class TCyMemoryBuffer(CyTransportBase):
     cdef TCyBuffer buf
@@ -22,7 +24,8 @@ cdef class TCyMemoryBuffer(CyTransportBase):
 
     cdef c_read(self, int sz, char* out):
         if self.buf.data_size < sz:
-            sz = self.buf.data_size
+            raise TTransportException(TTransportException.END_OF_FILE,
+                                      "End of file reading from transport")
 
         if sz <= 0:
             out[0] = '\0'
@@ -65,6 +68,10 @@ cdef class TCyMemoryBuffer(CyTransportBase):
         self.buf.write(sz, value)
 
     def read(self, sz):
+        # short reads are allowed here so this buffer can sit underneath a
+        # buffered transport, c_read used by the protocols is exact
+        if sz > self.buf.data_size:
+            sz = self.buf.data_size
         return self.get_string(sz)
 
     def write(self, data):


### PR DESCRIPTION
TCyMemoryBuffer.c_read used to silently shorten the read when the buffer did not hold enough bytes, and the cython binary protocol readers do not check the returned length, so truncated input was decoded into garbage from uninitialized stack memory. c_read now raises TTransportException END_OF_FILE like TCyBufferedTransport does, while the Python level read keeps returning short reads so the buffer can still sit underneath a buffered transport.