### PR TITLE
Add gunicorn worker classes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,6 +143,62 @@ Async Client
     if __name__ == '__main__':
         asyncio.run(main())
 
+Gunicorn
+--------
+
+``thriftpy2.contrib.gunicorn`` provides worker classes so a processor can be
+served by gunicorn, with its multi process management, graceful reload and
+the rest of its features. Expose a processor in a module:
+
+.. code:: python
+
+    # app.py
+    import thriftpy2
+    from thriftpy2.thrift import TProcessor
+
+    pingpong_thrift = thriftpy2.load("pingpong.thrift", module_name="pingpong_thrift")
+
+
+    class Dispatcher(object):
+        def ping(self):
+            return "pong"
+
+
+    app = TProcessor(pingpong_thrift.PingPong, Dispatcher())
+
+and start it with the gunicorn command:
+
+.. code:: bash
+
+    gunicorn -k thriftpy2.contrib.gunicorn.ThriftSyncWorker -w 4 -b 127.0.0.1:6000 app:app
+
+``ThriftSyncWorker`` handles one connection at a time per worker process.
+``ThriftAsyncWorker`` serves a ``TAsyncProcessor`` with async handlers on an
+asyncio event loop and handles many connections per process. Idle
+connections are closed after ``--keep-alive`` seconds, and ``--max-requests``
+counts thrift calls. The protocol and transport default to binary over
+buffered. To use others, subclass a worker and override ``proto_factory``
+and ``trans_factory``, which can be done right in the gunicorn config file:
+
+.. code:: python
+
+    # gunicorn.conf.py
+    from thriftpy2.contrib.gunicorn import ThriftSyncWorker
+    from thriftpy2.protocol import TCompactProtocolFactory
+    from thriftpy2.transport import TFramedTransportFactory
+
+
+    class Worker(ThriftSyncWorker):
+        proto_factory = TCompactProtocolFactory()
+        trans_factory = TFramedTransportFactory()
+
+
+    worker_class = Worker
+
+.. code:: bash
+
+    gunicorn -c gunicorn.conf.py -w 4 -b 127.0.0.1:6000 app:app
+
 See the ``examples`` and ``tests`` directories for more usage examples.
 
 

--- a/README.rst
+++ b/README.rst
@@ -146,9 +146,13 @@ Async Client
 Gunicorn
 --------
 
-``thriftpy2.contrib.gunicorn`` provides worker classes so a processor can be
-served by gunicorn, with its multi process management, graceful reload and
-the rest of its features. Expose a processor in a module:
+Running under gunicorn is the recommended way to serve thriftpy2 in
+production. A single Python process is limited to one core, while gunicorn
+forks multiple worker processes to use all of them, and brings mature process
+management on top, such as graceful shutdown and reload, automatic restart of
+crashed or leaking workers and adjusting the worker count at runtime.
+``thriftpy2.contrib.gunicorn`` provides the worker classes for it. Expose a
+processor in a module:
 
 .. code:: python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "pytest-reraise",
     "pytest>=6.1.1,<8.2.0",
     "aiohttp>=3.8.0,<4.0.0",
+    "gunicorn",
 ]
 
 aiohttp = [

--- a/tests/gunicorn_app.py
+++ b/tests/gunicorn_app.py
@@ -1,0 +1,33 @@
+"""Application module used by test_gunicorn.py, loaded by gunicorn."""
+import os
+
+import thriftpy2
+from thriftpy2.contrib.aio.processor import TAsyncProcessor
+from thriftpy2.thrift import TProcessor
+
+addressbook = thriftpy2.load(
+    os.path.join(os.path.dirname(__file__), "addressbook.thrift"))
+
+
+class Dispatcher:
+    def ping(self):
+        pass
+
+    def hello(self, name):
+        return "hello " + name
+
+
+class AsyncDispatcher:
+    async def ping(self):
+        pass
+
+    async def hello(self, name):
+        return "hello " + name
+
+
+app = TProcessor(addressbook.AddressBookService, Dispatcher())
+aio_app = TAsyncProcessor(addressbook.AddressBookService, AsyncDispatcher())
+
+
+def factory():
+    return app

--- a/tests/gunicorn_conf.py
+++ b/tests/gunicorn_conf.py
@@ -1,0 +1,16 @@
+"""Gunicorn config file used by test_gunicorn.py.
+
+Shows how to pick a protocol and transport by subclassing a worker right in
+the config file and assigning it to worker_class.
+"""
+from thriftpy2.contrib.gunicorn import ThriftSyncWorker
+from thriftpy2.protocol import TCompactProtocolFactory
+from thriftpy2.transport import TFramedTransportFactory
+
+
+class CompactFramedWorker(ThriftSyncWorker):
+    proto_factory = TCompactProtocolFactory()
+    trans_factory = TFramedTransportFactory()
+
+
+worker_class = CompactFramedWorker

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -381,13 +381,14 @@ class TestDeprecatedTimeoutKwarg:
     """
     def setup_method(self):
         # Create and apply a fresh patch for each test.
-        self.async_sock = patch(
+        self.patcher = patch(
             'thriftpy2.contrib.aio.rpc.TAsyncSocket',
             side_effect=RuntimeError,
-        ).__enter__()
+        )
+        self.async_sock = self.patcher.start()
 
     def teardown_method(self):
-        self.async_sock.__exit__()  # Clean up patch
+        self.patcher.stop()
 
     @pytest.mark.asyncio
     async def test_no_timeout_given(self):

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -1,0 +1,225 @@
+import asyncio
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+
+import pytest
+
+import thriftpy2
+from thriftpy2.rpc import make_aio_client, make_client
+from thriftpy2.transport import TTransportException
+
+pytest.importorskip("gunicorn")
+
+if sys.platform == "win32":
+    pytest.skip("gunicorn does not run on Windows", allow_module_level=True)
+
+TEST_DIR = os.path.dirname(__file__)
+addressbook = thriftpy2.load(os.path.join(TEST_DIR, "addressbook.thrift"))
+
+SYNC = "thriftpy2.contrib.gunicorn.ThriftSyncWorker"
+ASYNC = "thriftpy2.contrib.gunicorn.ThriftAsyncWorker"
+
+
+def free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def wait_for_port(port, timeout=15):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=1):
+                return
+        except OSError:
+            time.sleep(0.1)
+    raise RuntimeError("gunicorn did not start listening")
+
+
+class Gunicorn:
+    def __init__(self, worker, app="gunicorn_app:app", *extra):
+        self.port = free_port()
+        self.proc = subprocess.Popen(
+            [sys.executable, "-m", "gunicorn",
+             *(["-k", worker] if worker else []),
+             "-b", f"127.0.0.1:{self.port}", "--chdir", TEST_DIR,
+             "--log-level", "debug", *extra, app],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+        )
+        try:
+            wait_for_port(self.port)
+        except Exception:
+            self.stop()
+            raise RuntimeError(self.output)
+
+    def stop(self):
+        if self.proc.stdout.closed:
+            return self.output
+        if self.proc.poll() is None:
+            self.proc.send_signal(signal.SIGTERM)
+            try:
+                self.proc.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+                self.proc.wait()
+        self.output = self.proc.stdout.read()
+        self.proc.stdout.close()
+        return self.output
+
+    def client(self, **kwargs):
+        return make_client(addressbook.AddressBookService, "127.0.0.1",
+                           self.port, **kwargs)
+
+
+@pytest.fixture(params=[SYNC, ASYNC], ids=["sync", "async"])
+def server(request):
+    app = "gunicorn_app:aio_app" if request.param == ASYNC \
+        else "gunicorn_app:app"
+    srv = Gunicorn(request.param, app, "--keep-alive", "60")
+    yield srv
+    srv.stop()
+
+
+def test_rpc(server):
+    client = server.client()
+    try:
+        client.ping()
+        assert client.hello("world") == "hello world"
+        assert client.hello("again") == "hello again"
+    finally:
+        client.close()
+
+
+def test_several_connections(server):
+    for _ in range(3):
+        client = server.client()
+        try:
+            assert client.hello("x") == "hello x"
+        finally:
+            client.close()
+
+
+@pytest.mark.parametrize("worker, app", [
+    (SYNC, "gunicorn_app:app"), (ASYNC, "gunicorn_app:aio_app")],
+    ids=["sync", "async"])
+def test_idle_connection_closed(worker, app):
+    srv = Gunicorn(worker, app, "--keep-alive", "1")
+    try:
+        client = srv.client(timeout=5000)
+        assert client.hello("x") == "hello x"
+        time.sleep(2)
+        with pytest.raises(TTransportException):
+            client.hello("y")
+        client.close()
+    finally:
+        srv.stop()
+
+
+def test_factory_app():
+    srv = Gunicorn(SYNC, "gunicorn_app:factory")
+    try:
+        client = srv.client()
+        assert client.hello("f") == "hello f"
+        client.close()
+    finally:
+        srv.stop()
+
+
+def test_factory_app_preload():
+    srv = Gunicorn(SYNC, "gunicorn_app:factory", "--preload")
+    try:
+        client = srv.client()
+        assert client.hello("p") == "hello p"
+        client.close()
+    finally:
+        srv.stop()
+
+
+def test_max_requests_restarts_worker():
+    srv = Gunicorn(SYNC, "gunicorn_app:app", "--max-requests", "2",
+                   "--keep-alive", "60")
+    try:
+        client = srv.client()
+        assert client.hello("1") == "hello 1"
+        assert client.hello("2") == "hello 2"
+        # the worker closes the connection after the second request
+        with pytest.raises(TTransportException):
+            client.hello("3")
+        client.close()
+        wait_for_port(srv.port)
+        client = srv.client()
+        assert client.hello("4") == "hello 4"
+        client.close()
+    finally:
+        out = srv.stop()
+    assert "Autorestarting worker" in out
+
+
+def test_async_worker_concurrent_clients():
+    srv = Gunicorn(ASYNC, "gunicorn_app:aio_app", "--keep-alive", "60")
+
+    async def run():
+        clients = [await make_aio_client(addressbook.AddressBookService,
+                                         "127.0.0.1", srv.port)
+                   for _ in range(5)]
+        try:
+            results = await asyncio.gather(
+                *(c.hello(str(i)) for i, c in enumerate(clients)))
+            assert results == [f"hello {i}" for i in range(5)]
+        finally:
+            for c in clients:
+                c.close()
+
+    try:
+        asyncio.run(run())
+    finally:
+        srv.stop()
+
+
+def test_wrong_app_object_fails():
+    port = free_port()
+    proc = subprocess.run(
+        [sys.executable, "-m", "gunicorn", "-k", SYNC,
+         "-b", f"127.0.0.1:{port}", "--chdir", TEST_DIR,
+         "gunicorn_app:addressbook"],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+        timeout=30)
+    assert proc.returncode != 0
+    assert "thrift processor" in proc.stdout
+
+
+def test_async_worker_sigterm_closes_idle_connection():
+    srv = Gunicorn(ASYNC, "gunicorn_app:aio_app", "--keep-alive", "60")
+    client = srv.client(timeout=5000)
+    try:
+        assert client.hello("x") == "hello x"
+        start = time.time()
+        srv.proc.send_signal(signal.SIGTERM)
+        srv.proc.wait(timeout=15)
+        assert time.time() - start < 10
+        with pytest.raises(TTransportException):
+            client.hello("y")
+    finally:
+        client.close()
+        srv.stop()
+
+
+def test_custom_protocol_and_transport_from_config_file():
+    from thriftpy2.protocol import TCompactProtocolFactory
+    from thriftpy2.transport import TFramedTransportFactory
+
+    srv = Gunicorn(None, "gunicorn_app:app", "-c",
+                   os.path.join(TEST_DIR, "gunicorn_conf.py"))
+    try:
+        client = srv.client(proto_factory=TCompactProtocolFactory(),
+                            trans_factory=TFramedTransportFactory())
+        assert client.hello("compact") == "hello compact"
+        client.close()
+    finally:
+        out = srv.stop()
+    assert "CompactFramedWorker" in out

--- a/thriftpy2/contrib/gunicorn/__init__.py
+++ b/thriftpy2/contrib/gunicorn/__init__.py
@@ -1,0 +1,37 @@
+"""Gunicorn worker classes for serving ThriftPy2 processors.
+
+Write a module that exposes a processor::
+
+    # app.py
+    import thriftpy2
+    from thriftpy2.thrift import TProcessor
+
+    pingpong_thrift = thriftpy2.load("pingpong.thrift")
+
+    class Dispatcher:
+        def ping(self):
+            return "pong"
+
+    app = TProcessor(pingpong_thrift.PingService, Dispatcher())
+
+and run it with the stock gunicorn command line::
+
+    gunicorn -k thriftpy2.contrib.gunicorn.ThriftSyncWorker app:app
+
+The application object can be a processor instance, or a zero argument
+callable returning one. Gunicorn itself only accepts callables when
+``--preload`` is used, so the callable form is required there.
+
+``ThriftAsyncWorker`` serves a ``TAsyncProcessor`` from
+``thriftpy2.contrib.aio`` on an asyncio event loop, handling many
+connections per worker process.
+
+Protocol and transport factories default to binary over buffered and can be
+changed by subclassing a worker and overriding ``proto_factory`` and
+``trans_factory``, then pointing ``-k`` at the subclass.
+"""
+
+from .sync import ThriftSyncWorker
+from .aio import ThriftAsyncWorker
+
+__all__ = ["ThriftSyncWorker", "ThriftAsyncWorker"]

--- a/thriftpy2/contrib/gunicorn/aio.py
+++ b/thriftpy2/contrib/gunicorn/aio.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import asyncio
+import errno
+import os
+import signal
+import sys
+
+from gunicorn import sock as gsock
+from gunicorn.workers import base
+
+from thriftpy2.contrib.aio.protocol.binary import TAsyncBinaryProtocolFactory
+from thriftpy2.contrib.aio.socket import StreamHandler
+from thriftpy2.contrib.aio.transport.buffered import (
+    TAsyncBufferedTransportFactory,
+)
+from thriftpy2.transport import TTransportException
+
+from .base import ThriftWorkerMixin
+
+
+class _ClientStream(StreamHandler):
+    """StreamHandler whose first read of each message honours an idle timeout.
+
+    The worker marks the stream idle between requests. The read that starts
+    the next message is bounded by the timeout while reads inside a message
+    are not, so a slow request is never cut short by the keepalive setting.
+    """
+
+    def __init__(self, reader, writer, idle_timeout):
+        super().__init__(reader, writer)
+        self.idle_timeout = idle_timeout
+        self.idle = True
+
+    async def read(self, sz):
+        if self.idle and self.idle_timeout:
+            buff = await asyncio.wait_for(super().read(sz), self.idle_timeout)
+        else:
+            buff = await super().read(sz)
+        self.idle = False
+        return buff
+
+
+class ThriftAsyncWorker(ThriftWorkerMixin, base.Worker):
+    """Serve a ``TAsyncProcessor`` on an asyncio event loop.
+
+    Each connection runs as a task, so one worker handles up to
+    ``--worker-connections`` clients concurrently. Connections are closed
+    after ``--keep-alive`` seconds without a request, and ``--max-requests``
+    counts thrift calls across all connections.
+    """
+
+    proto_factory = TAsyncBinaryProtocolFactory()
+    trans_factory = TAsyncBufferedTransportFactory()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.loop = None
+        self.servers = []
+        self.connections = {}
+        self.quick_shutdown = False
+
+    @classmethod
+    def check_config(cls, cfg, log):
+        if cfg.threads > 1:
+            log.warning("ThriftAsyncWorker does not use the threads "
+                        "setting, use worker_connections instead.")
+
+    def init_process(self):
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+        super().init_process()
+
+    def init_signals(self):
+        for s in self.SIGNALS:
+            signal.signal(s, signal.SIG_DFL)
+        self.loop.add_signal_handler(signal.SIGQUIT, self.handle_quit_signal)
+        self.loop.add_signal_handler(signal.SIGINT, self.handle_quit_signal)
+        self.loop.add_signal_handler(signal.SIGTERM, self.handle_exit_signal)
+        self.loop.add_signal_handler(signal.SIGUSR1, self.log.reopen_files)
+        self.loop.add_signal_handler(signal.SIGABRT, self.handle_abort_signal)
+        self.loop.add_signal_handler(
+            signal.SIGWINCH, lambda: self.log.debug("worker: SIGWINCH ignored."))
+
+    def handle_quit_signal(self):
+        self.quick_shutdown = True
+        if self.alive:
+            self.alive = False
+            self.cfg.worker_int(self)
+
+    def handle_exit_signal(self):
+        self.alive = False
+
+    def handle_abort_signal(self):
+        self.alive = False
+        self.cfg.worker_abort(self)
+        sys.exit(1)
+
+    def run(self):
+        try:
+            self.loop.run_until_complete(self.serve())
+        except Exception:
+            self.log.exception("Worker exception")
+        finally:
+            self.cleanup()
+
+    async def serve(self):
+        ssl_context = gsock.ssl_context(self.cfg) if self.cfg.is_ssl else None
+        for s in self.sockets:
+            server = await asyncio.start_server(
+                self.handle, sock=s.sock, ssl=ssl_context)
+            self.servers.append(server)
+
+        while self.alive:
+            self.notify()
+            if self.ppid != os.getppid():
+                self.log.info("Parent changed, shutting down: %s", self)
+                break
+            await asyncio.sleep(1.0)
+
+        await self.shutdown()
+
+    async def handle(self, reader, writer):
+        addr = writer.get_extra_info("peername")
+        if len(self.connections) >= self.cfg.worker_connections:
+            self.log.warning("Connection limit reached, dropping %s", addr)
+            writer.close()
+            return
+        task = asyncio.current_task()
+        client = _ClientStream(reader, writer, self.cfg.keepalive or None)
+        self.connections[task] = client
+        itrans, otrans, iprot, oprot = self.make_protocols(client)
+        try:
+            while self.alive:
+                client.idle = True
+                await self.processor.process(iprot, oprot)
+                self.nr += 1
+                if self.nr >= self.max_requests:
+                    self.log.info("Autorestarting worker after current "
+                                  "request.")
+                    self.alive = False
+        except TTransportException as e:
+            if e.type != TTransportException.END_OF_FILE:
+                self.log.warning("Transport error from %s: %s", addr, e)
+        except asyncio.TimeoutError:
+            self.log.debug("Closing idle connection from %s", addr)
+        except asyncio.CancelledError:
+            pass
+        except (ConnectionError, OSError) as e:
+            if e.errno in (errno.ECONNRESET, errno.EPIPE, errno.ENOTCONN) \
+                    or isinstance(e, ConnectionError):
+                self.log.debug("Connection from %s dropped: %s", addr, e)
+            else:
+                self.log.exception("Socket error from %s", addr)
+        except Exception:
+            self.log.exception("Error processing request from %s", addr)
+        finally:
+            self.connections.pop(task, None)
+            itrans.close()
+            otrans.close()
+
+    async def shutdown(self):
+        for server in self.servers:
+            server.close()
+
+        # idle connections are closed right away, connections with a
+        # request in flight get graceful_timeout to finish it
+        if self.connections and not self.quick_shutdown:
+            self.log.info("Waiting for %d connections to finish...",
+                          len(self.connections))
+            deadline = self.loop.time() + self.cfg.graceful_timeout
+            while self.connections and self.loop.time() < deadline:
+                if self.quick_shutdown:
+                    break
+                for task, client in list(self.connections.items()):
+                    if client.idle:
+                        task.cancel()
+                await asyncio.sleep(0.1)
+
+        for task in list(self.connections):
+            task.cancel()
+        if self.connections:
+            await asyncio.gather(*self.connections, return_exceptions=True)
+
+    def cleanup(self):
+        try:
+            pending = asyncio.all_tasks(self.loop)
+            for task in pending:
+                task.cancel()
+            if pending:
+                self.loop.run_until_complete(
+                    asyncio.gather(*pending, return_exceptions=True))
+            self.loop.close()
+        except Exception as e:
+            self.log.debug("Cleanup error: %s", e)

--- a/thriftpy2/contrib/gunicorn/aio.py
+++ b/thriftpy2/contrib/gunicorn/aio.py
@@ -53,11 +53,13 @@ class ThriftAsyncWorker(ThriftWorkerMixin, base.Worker):
     proto_factory = TAsyncBinaryProtocolFactory()
     trans_factory = TAsyncBufferedTransportFactory()
 
+    loop: asyncio.AbstractEventLoop
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.loop = None
-        self.servers = []
-        self.connections = {}
+        # the loop is created in init_process, after the fork
+        self.servers: list[asyncio.AbstractServer] = []
+        self.connections: dict[asyncio.Task, _ClientStream] = {}
         self.quick_shutdown = False
 
     @classmethod
@@ -108,7 +110,7 @@ class ThriftAsyncWorker(ThriftWorkerMixin, base.Worker):
         ssl_context = gsock.ssl_context(self.cfg) if self.cfg.is_ssl else None
         for s in self.sockets:
             server = await asyncio.start_server(
-                self.handle, sock=s.sock, ssl=ssl_context)
+                self.handle, sock=getattr(s, "sock", s), ssl=ssl_context)
             self.servers.append(server)
 
         while self.alive:
@@ -127,6 +129,7 @@ class ThriftAsyncWorker(ThriftWorkerMixin, base.Worker):
             writer.close()
             return
         task = asyncio.current_task()
+        assert task is not None
         client = _ClientStream(reader, writer, self.cfg.keepalive or None)
         self.connections[task] = client
         itrans, otrans, iprot, oprot = self.make_protocols(client)

--- a/thriftpy2/contrib/gunicorn/base.py
+++ b/thriftpy2/contrib/gunicorn/base.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import importlib
+import os
+from typing import Any
+
+from gunicorn.errors import AppImportError
+
+
+def import_processor(uri: str) -> Any:
+    """Import ``module:obj`` without gunicorn's callable requirement."""
+    module, sep, name = uri.partition(":")
+    if not sep:
+        name = "app"
+    try:
+        mod = importlib.import_module(module)
+    except ImportError:
+        if module.endswith(".py") and os.path.exists(module):
+            raise ImportError(
+                "Failed to find application, did you mean '%s:%s'?"
+                % (module.rsplit(".", 1)[0], name))
+        raise
+    try:
+        return getattr(mod, name)
+    except AttributeError:
+        raise AppImportError(
+            "Failed to find attribute %r in %r." % (name, module))
+
+
+def resolve_processor(obj: Any) -> Any:
+    """Accept a processor, or a zero argument factory returning one."""
+    if obj is None:
+        raise AppImportError("Failed to find thrift processor.")
+    if not hasattr(obj, "process") and callable(obj):
+        obj = obj()
+    if not hasattr(obj, "process"):
+        raise AppImportError(
+            "Application object must be a thrift processor or a callable "
+            "returning one, got %r." % (obj,))
+    return obj
+
+
+class ThriftWorkerMixin:
+    """Shared processor loading for the thrift workers."""
+
+    proto_factory: Any = None
+    trans_factory: Any = None
+
+    def load_wsgi(self) -> None:
+        app = self.app  # type: ignore[attr-defined]
+        # Gunicorn's own loader rejects non callable objects, so when the
+        # application has not been loaded yet (no --preload) import the
+        # object ourselves. Custom Application subclasses without app_uri
+        # fall back to the regular wsgi() path.
+        if getattr(app, "callable", None) is None and \
+                getattr(app, "app_uri", None):
+            obj = import_processor(app.app_uri)
+        else:
+            obj = app.wsgi()
+        self.processor = resolve_processor(obj)
+
+    def make_protocols(self, client: Any) -> tuple[Any, Any, Any, Any]:
+        itrans = self.trans_factory.get_transport(client)
+        iprot = self.proto_factory.get_protocol(itrans)
+        if getattr(self.proto_factory, "shared_instance", False):
+            return itrans, itrans, iprot, iprot
+        otrans = self.trans_factory.get_transport(client)
+        oprot = self.proto_factory.get_protocol(otrans)
+        return itrans, otrans, iprot, oprot

--- a/thriftpy2/contrib/gunicorn/sync.py
+++ b/thriftpy2/contrib/gunicorn/sync.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import errno
+import socket
+
+from gunicorn import sock as gsock
+from gunicorn.workers.sync import SyncWorker
+
+from thriftpy2.protocol import TBinaryProtocolFactory
+from thriftpy2.transport import (
+    TBufferedTransportFactory,
+    TSocket,
+    TTransportException,
+)
+
+from .base import ThriftWorkerMixin
+
+
+class ThriftSyncWorker(ThriftWorkerMixin, SyncWorker):
+    """Serve one thrift connection at a time, like gunicorn's sync worker.
+
+    The connection is kept open and requests are processed in sequence until
+    the client closes it, no request arrives within ``--keep-alive`` seconds,
+    or the worker is asked to exit. ``--max-requests`` counts thrift calls.
+    """
+
+    proto_factory = TBinaryProtocolFactory()
+    trans_factory = TBufferedTransportFactory()
+
+    def handle(self, listener, client, addr):
+        if self.cfg.is_ssl:
+            client = gsock.ssl_wrap_socket(client, self.cfg)
+        client.settimeout(self.cfg.keepalive or None)
+
+        tsock = TSocket()
+        tsock.set_handle(client)
+        itrans, otrans, iprot, oprot = self.make_protocols(tsock)
+        try:
+            while self.alive:
+                self.processor.process(iprot, oprot)
+                self.nr += 1
+                if self.nr >= self.max_requests:
+                    self.log.info("Autorestarting worker after current "
+                                  "request.")
+                    self.alive = False
+                self.notify()
+        except TTransportException as e:
+            if e.type != TTransportException.END_OF_FILE:
+                self.log.warning("Transport error from %s: %s", addr, e)
+        except socket.timeout:
+            self.log.debug("Closing idle connection from %s", addr)
+        except OSError as e:
+            if e.errno in (errno.ECONNRESET, errno.EPIPE, errno.ENOTCONN):
+                self.log.debug("Connection from %s dropped: %s", addr, e)
+            else:
+                self.log.exception("Socket error from %s", addr)
+        except Exception:
+            self.log.exception("Error processing request from %s", addr)
+        finally:
+            itrans.close()
+            otrans.close()

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps =
     cython
     pytest_asyncio
     thrift
+    gunicorn
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
Add `thriftpy2.contrib.gunicorn` so a thrift processor can be served by the stock `gunicorn` command, getting its multi process management and graceful reload for free. gunicorn stays an optional install.