### PR TITLE
Guard cybin struct (de)serialization against native stack overflow

### DIFF
--- a/tests/test_aio_protocol_binary.py
+++ b/tests/test_aio_protocol_binary.py
@@ -29,3 +29,128 @@ async def test_strict_decode():
     with pytest.raises(UnicodeDecodeError):
         await proto.read_val(bs, TType.STRING, decode_response=True,
                              strict_decode=True)
+
+
+class TTree(TPayload):
+    thrift_spec = {
+        1: (TType.I32, "v", False),
+        2: (TType.STRUCT, "child", None, False),
+        3: (TType.LIST, "children", None, False),
+    }
+    default_spec = [("v", None), ("child", None), ("children", None)]
+
+
+TTree.thrift_spec[2] = (TType.STRUCT, "child", TTree, False)
+TTree.thrift_spec[3] = (TType.LIST, "children", (TType.STRUCT, TTree), False)
+
+
+def make_tree(depth, in_list=False):
+    root = TTree(v=0)
+    node = root
+    for i in range(1, depth + 1):
+        child = TTree(v=i)
+        if in_list:
+            node.children = [child]
+        else:
+            node.child = child
+        node = child
+    return root
+
+
+def tree_depth(obj):
+    depth = 0
+    while obj.child is not None or obj.children:
+        obj = obj.child if obj.child is not None else obj.children[0]
+        depth += 1
+    return depth
+
+
+def encode(obj, **kwargs):
+    b = BytesIO()
+    proto.TAsyncBinaryProtocol(b, **kwargs).write_struct(obj)
+    return b.getvalue()
+
+
+async def decode(blob, cls=TTree, **kwargs):
+    obj = cls()
+    b = AsyncBytesIO(BytesIO(blob))
+    await proto.TAsyncBinaryProtocol(b, **kwargs).read_struct(obj)
+    return obj
+
+
+# The root struct counts as a level too, and the extra struct above the list
+# chain makes it overflow on a list instead of a struct.
+LIMIT = proto.DEFAULT_MAX_DEPTH
+DEEPEST = make_tree(LIMIT - 1)
+DEEPEST_LIST = make_tree((LIMIT - 2) // 2, in_list=True)
+TOO_DEEP = make_tree(LIMIT)
+TOO_DEEP_LIST = TTree(v=0, child=make_tree(LIMIT // 2, in_list=True))
+
+
+@pytest.mark.asyncio
+async def test_nested_struct_within_limit():
+    assert tree_depth(await decode(encode(DEEPEST))) == LIMIT - 1
+    assert tree_depth(await decode(encode(DEEPEST_LIST))) == (LIMIT - 2) // 2
+
+
+def test_deeply_nested_write_raises_recursion_error():
+    with pytest.raises(RecursionError, match="while writing a Thrift struct"):
+        encode(TOO_DEEP)
+    with pytest.raises(RecursionError,
+                       match="while writing a Thrift container"):
+        encode(TOO_DEEP_LIST)
+
+
+@pytest.mark.asyncio
+async def test_deeply_nested_read_raises_recursion_error():
+    blob = encode(TOO_DEEP, max_depth=LIMIT + 8)
+    with pytest.raises(RecursionError, match="while reading a Thrift struct"):
+        await decode(blob)
+    blob = encode(TOO_DEEP_LIST, max_depth=LIMIT + 8)
+    with pytest.raises(RecursionError,
+                       match="while reading a Thrift container"):
+        await decode(blob)
+
+
+@pytest.mark.asyncio
+async def test_deeply_nested_skip_raises_recursion_error():
+    # TItem has a list where TTree has its child struct, so the subtree is
+    # skipped rather than read.
+    blob = encode(TOO_DEEP, max_depth=LIMIT + 8)
+    with pytest.raises(RecursionError, match="while skipping a Thrift struct"):
+        await decode(blob, TItem)
+    with pytest.raises(RecursionError):
+        await proto.skip(AsyncBytesIO(BytesIO(blob)), TType.STRUCT)
+    with pytest.raises(RecursionError):
+        b = AsyncBytesIO(BytesIO(blob))
+        await proto.TAsyncBinaryProtocol(b).skip(TType.STRUCT)
+
+    blob = encode(TOO_DEEP_LIST, max_depth=LIMIT + 8)
+    with pytest.raises(RecursionError,
+                       match="while skipping a Thrift container"):
+        await decode(blob, TItem)
+
+
+@pytest.mark.asyncio
+async def test_max_depth_is_configurable():
+    depth = LIMIT * 4
+    obj = make_tree(depth)
+    blob = encode(obj, max_depth=depth + 1)
+    assert tree_depth(await decode(blob, max_depth=depth + 1)) == depth
+    await decode(blob, TItem, max_depth=depth + 1)
+    b = AsyncBytesIO(BytesIO(blob))
+    await proto.TAsyncBinaryProtocol(b, max_depth=depth + 1).skip(TType.STRUCT)
+
+    with pytest.raises(RecursionError):
+        encode(obj, max_depth=depth)
+    with pytest.raises(RecursionError):
+        await decode(blob, max_depth=depth)
+    with pytest.raises(RecursionError):
+        await decode(blob, TItem, max_depth=depth)
+
+    factory = proto.TAsyncBinaryProtocolFactory(max_depth=depth + 1)
+    p = factory.get_protocol(AsyncBytesIO(BytesIO(blob)))
+    assert p.max_depth == depth + 1
+    obj = TTree()
+    await p.read_struct(obj)
+    assert tree_depth(obj) == depth

--- a/tests/test_protocol_binary.py
+++ b/tests/test_protocol_binary.py
@@ -284,3 +284,121 @@ def string_binary_equivalency(proto_factory):
 
     assert serialize(l_struct, proto_factory=proto_factory()) == serialize(
         bl_struct, proto_factory=proto_factory())
+
+
+class TTree(TPayload):
+    thrift_spec = {
+        1: (TType.I32, "v", False),
+        2: (TType.STRUCT, "child", None, False),
+        3: (TType.LIST, "children", None, False),
+    }
+    default_spec = [("v", None), ("child", None), ("children", None)]
+
+
+TTree.thrift_spec[2] = (TType.STRUCT, "child", TTree, False)
+TTree.thrift_spec[3] = (TType.LIST, "children", (TType.STRUCT, TTree), False)
+
+
+def make_tree(depth, in_list=False):
+    root = TTree(v=0)
+    node = root
+    for i in range(1, depth + 1):
+        child = TTree(v=i)
+        if in_list:
+            node.children = [child]
+        else:
+            node.child = child
+        node = child
+    return root
+
+
+def tree_depth(obj):
+    depth = 0
+    while obj.child is not None or obj.children:
+        obj = obj.child if obj.child is not None else obj.children[0]
+        depth += 1
+    return depth
+
+
+def encode(obj, **kwargs):
+    b = BytesIO()
+    proto.TBinaryProtocol(b, **kwargs).write_struct(obj)
+    return b.getvalue()
+
+
+def decode(blob, cls=TTree, **kwargs):
+    obj = cls()
+    proto.TBinaryProtocol(BytesIO(blob), **kwargs).read_struct(obj)
+    return obj
+
+
+# The root struct counts as a level too, and the extra struct above the list
+# chain makes it overflow on a list instead of a struct.
+LIMIT = proto.DEFAULT_MAX_DEPTH
+DEEPEST = make_tree(LIMIT - 1)
+DEEPEST_LIST = make_tree((LIMIT - 2) // 2, in_list=True)
+TOO_DEEP = make_tree(LIMIT)
+TOO_DEEP_LIST = TTree(v=0, child=make_tree(LIMIT // 2, in_list=True))
+
+
+def test_nested_struct_within_limit():
+    assert tree_depth(decode(encode(DEEPEST))) == LIMIT - 1
+    assert tree_depth(decode(encode(DEEPEST_LIST))) == (LIMIT - 2) // 2
+
+
+def test_deeply_nested_write_raises_recursion_error():
+    with pytest.raises(RecursionError, match="while writing a Thrift struct"):
+        encode(TOO_DEEP)
+    with pytest.raises(RecursionError,
+                       match="while writing a Thrift container"):
+        encode(TOO_DEEP_LIST)
+
+
+def test_deeply_nested_read_raises_recursion_error():
+    blob = encode(TOO_DEEP, max_depth=LIMIT + 8)
+    with pytest.raises(RecursionError, match="while reading a Thrift struct"):
+        decode(blob)
+    blob = encode(TOO_DEEP_LIST, max_depth=LIMIT + 8)
+    with pytest.raises(RecursionError,
+                       match="while reading a Thrift container"):
+        decode(blob)
+
+
+def test_deeply_nested_skip_raises_recursion_error():
+    # TItem has a list where TTree has its child struct, so the subtree is
+    # skipped rather than read.
+    blob = encode(TOO_DEEP, max_depth=LIMIT + 8)
+    with pytest.raises(RecursionError, match="while skipping a Thrift struct"):
+        decode(blob, TItem)
+    with pytest.raises(RecursionError):
+        proto.skip(BytesIO(blob), TType.STRUCT)
+    with pytest.raises(RecursionError):
+        proto.TBinaryProtocol(BytesIO(blob)).skip(TType.STRUCT)
+
+    blob = encode(TOO_DEEP_LIST, max_depth=LIMIT + 8)
+    with pytest.raises(RecursionError,
+                       match="while skipping a Thrift container"):
+        decode(blob, TItem)
+
+
+def test_max_depth_is_configurable():
+    depth = LIMIT * 4
+    obj = make_tree(depth)
+    blob = encode(obj, max_depth=depth + 1)
+    assert tree_depth(decode(blob, max_depth=depth + 1)) == depth
+    decode(blob, TItem, max_depth=depth + 1)
+    proto.TBinaryProtocol(BytesIO(blob), max_depth=depth + 1).skip(TType.STRUCT)
+
+    with pytest.raises(RecursionError):
+        encode(obj, max_depth=depth)
+    with pytest.raises(RecursionError):
+        decode(blob, max_depth=depth)
+    with pytest.raises(RecursionError):
+        decode(blob, TItem, max_depth=depth)
+
+    factory = proto.TBinaryProtocolFactory(max_depth=depth + 1)
+    p = factory.get_protocol(BytesIO(blob))
+    assert p.max_depth == depth + 1
+    obj = TTree()
+    p.read_struct(obj)
+    assert tree_depth(obj) == depth

--- a/tests/test_protocol_cybinary.py
+++ b/tests/test_protocol_cybinary.py
@@ -516,3 +516,119 @@ def test_type_tolerance():
 
     for obj in cases:
         p.write_struct(obj)
+
+
+class TTree(TPayload):
+    thrift_spec = {
+        1: (TType.I32, "v", False),
+        2: (TType.STRUCT, "child", None, False),
+        3: (TType.LIST, "children", None, False),
+    }
+    default_spec = [("v", None), ("child", None), ("children", None)]
+
+
+TTree.thrift_spec[2] = (TType.STRUCT, "child", TTree, False)
+TTree.thrift_spec[3] = (TType.LIST, "children", (TType.STRUCT, TTree), False)
+
+
+def make_tree(depth, in_list=False):
+    root = TTree(v=0)
+    node = root
+    for i in range(1, depth + 1):
+        child = TTree(v=i)
+        if in_list:
+            node.children = [child]
+        else:
+            node.child = child
+        node = child
+    return root
+
+
+def tree_depth(obj):
+    depth = 0
+    while obj.child is not None or obj.children:
+        obj = obj.child if obj.child is not None else obj.children[0]
+        depth += 1
+    return depth
+
+
+def encode(obj, **kwargs):
+    buf = TCyMemoryBuffer()
+    proto.TCyBinaryProtocol(buf, **kwargs).write_struct(obj)
+    return buf.getvalue()
+
+
+def decode(blob, cls=TTree, **kwargs):
+    buf = TCyMemoryBuffer(blob)
+    return proto.TCyBinaryProtocol(buf, **kwargs).read_struct(cls())
+
+
+# The root struct counts as a level too, and the extra struct above the list
+# chain makes it overflow on a list instead of a struct.
+LIMIT = proto.DEFAULT_MAX_DEPTH
+DEEPEST = make_tree(LIMIT - 1)
+DEEPEST_LIST = make_tree((LIMIT - 2) // 2, in_list=True)
+TOO_DEEP = make_tree(LIMIT)
+TOO_DEEP_LIST = TTree(v=0, child=make_tree(LIMIT // 2, in_list=True))
+
+
+def test_nested_struct_within_limit():
+    assert tree_depth(decode(encode(DEEPEST))) == LIMIT - 1
+    assert tree_depth(decode(encode(DEEPEST_LIST))) == (LIMIT - 2) // 2
+
+
+def test_deeply_nested_write_raises_recursion_error():
+    with pytest.raises(RecursionError, match="while writing a Thrift struct"):
+        encode(TOO_DEEP)
+    with pytest.raises(RecursionError,
+                       match="while writing a Thrift container"):
+        encode(TOO_DEEP_LIST)
+
+
+def test_deeply_nested_read_raises_recursion_error():
+    blob = encode(TOO_DEEP, max_depth=LIMIT + 8)
+    with pytest.raises(RecursionError, match="while reading a Thrift struct"):
+        decode(blob)
+    blob = encode(TOO_DEEP_LIST, max_depth=LIMIT + 8)
+    with pytest.raises(RecursionError,
+                       match="while reading a Thrift container"):
+        decode(blob)
+
+
+def test_deeply_nested_skip_raises_recursion_error():
+    # TItem has a list where TTree has its child struct, so the subtree is
+    # skipped rather than read.
+    blob = encode(TOO_DEEP, max_depth=LIMIT + 8)
+    with pytest.raises(RecursionError, match="while skipping a Thrift struct"):
+        decode(blob, TItem)
+    with pytest.raises(RecursionError):
+        proto.skip(TCyMemoryBuffer(blob), TType.STRUCT)
+    with pytest.raises(RecursionError):
+        proto.TCyBinaryProtocol(TCyMemoryBuffer(blob)).skip(TType.STRUCT)
+
+    blob = encode(TOO_DEEP_LIST, max_depth=LIMIT + 8)
+    with pytest.raises(RecursionError,
+                       match="while skipping a Thrift container"):
+        decode(blob, TItem)
+
+
+def test_max_depth_is_configurable():
+    depth = LIMIT * 4
+    obj = make_tree(depth)
+    blob = encode(obj, max_depth=depth + 1)
+    assert tree_depth(decode(blob, max_depth=depth + 1)) == depth
+    decode(blob, TItem, max_depth=depth + 1)
+    p = proto.TCyBinaryProtocol(TCyMemoryBuffer(blob), max_depth=depth + 1)
+    p.skip(TType.STRUCT)
+
+    with pytest.raises(RecursionError):
+        encode(obj, max_depth=depth)
+    with pytest.raises(RecursionError):
+        decode(blob, max_depth=depth)
+    with pytest.raises(RecursionError):
+        decode(blob, TItem, max_depth=depth)
+
+    factory = proto.TCyBinaryProtocolFactory(max_depth=depth + 1)
+    p = factory.get_protocol(TCyMemoryBuffer(blob))
+    assert p.max_depth == depth + 1
+    assert tree_depth(p.read_struct(TTree())) == depth

--- a/thriftpy2/contrib/aio/protocol/binary.py
+++ b/thriftpy2/contrib/aio/protocol/binary.py
@@ -4,9 +4,11 @@ from thriftpy2.thrift import TType
 
 from thriftpy2.protocol.exc import TProtocolException
 from thriftpy2.protocol.binary import (
+    DEFAULT_MAX_DEPTH,
     VERSION_MASK,
     VERSION_1,
     TYPE_MASK,
+    check_depth,
     unpack_i8,
     unpack_i16,
     unpack_i32,
@@ -69,7 +71,7 @@ async def read_map_begin(inbuf):
 
 
 async def read_val(inbuf, ttype, spec: Any = None, decode_response=True,
-                   strict_decode=False):
+                   strict_decode=False, budget=DEFAULT_MAX_DEPTH):
     if ttype == TType.BOOL:
         return bool(unpack_i8(await inbuf.read(1)))
 
@@ -112,19 +114,21 @@ async def read_val(inbuf, ttype, spec: Any = None, decode_response=True,
         else:
             v_type, v_spec = spec, None
 
+        check_depth(budget, " while reading a Thrift container")
+        budget -= 1
         result = []
         r_type, sz = await read_list_begin(inbuf)
         # the v_type is useless here since we already get it from spec
         if (r_type != v_type
                 and not (r_type in BIN_TYPES and v_type in BIN_TYPES)):
             for _ in range(sz):
-                await skip(inbuf, r_type)
+                await skip(inbuf, r_type, budget)
             return []
 
         for i in range(sz):
             result.append(
                 await read_val(inbuf, v_type, v_spec, decode_response,
-                               strict_decode)
+                               strict_decode, budget)
             )
         return result
 
@@ -141,6 +145,8 @@ async def read_val(inbuf, ttype, spec: Any = None, decode_response=True,
         else:
             v_type, v_spec = spec[1]
 
+        check_depth(budget, " while reading a Thrift container")
+        budget -= 1
         result = {}
         sk_type, sv_type, sz = await read_map_begin(inbuf)
         if sk_type in BIN_TYPES:
@@ -149,33 +155,36 @@ async def read_val(inbuf, ttype, spec: Any = None, decode_response=True,
             sv_type = v_type
         if sk_type != k_type or sv_type != v_type:
             for _ in range(sz):
-                await skip(inbuf, sk_type)
-                await skip(inbuf, sv_type)
+                await skip(inbuf, sk_type, budget)
+                await skip(inbuf, sv_type, budget)
             return {}
 
         for i in range(sz):
             k_val = await read_val(inbuf, k_type, k_spec, decode_response,
-                                   strict_decode)
+                                   strict_decode, budget)
             v_val = await read_val(inbuf, v_type, v_spec, decode_response,
-                                   strict_decode)
+                                   strict_decode, budget)
             result[k_val] = v_val
 
         return result
 
     elif ttype == TType.STRUCT:
         obj = spec()
-        await read_struct(inbuf, obj, decode_response, strict_decode)
+        await read_struct(inbuf, obj, decode_response, strict_decode, budget)
         return obj
 
 
-async def read_struct(inbuf, obj, decode_response=True, strict_decode=False):
+async def read_struct(inbuf, obj, decode_response=True, strict_decode=False,
+                      budget=DEFAULT_MAX_DEPTH):
+    check_depth(budget, " while reading a Thrift struct")
+    budget -= 1
     while True:
         f_type, fid = await read_field_begin(inbuf)
         if f_type == TType.STOP:
             break
 
         if fid not in obj.thrift_spec:
-            await skip(inbuf, f_type)
+            await skip(inbuf, f_type, budget)
             continue
 
         if len(obj.thrift_spec[fid]) == 3:
@@ -190,15 +199,16 @@ async def read_struct(inbuf, obj, decode_response=True, strict_decode=False):
             if f_type in BIN_TYPES:
                 f_type = sf_type
             else:
-                await skip(inbuf, f_type)
+                await skip(inbuf, f_type, budget)
                 continue
 
         _buf = await read_val(
-            inbuf, f_type, f_container_spec, decode_response, strict_decode)
+            inbuf, f_type, f_container_spec, decode_response, strict_decode,
+            budget)
         setattr(obj, f_name, _buf)
 
 
-async def skip(inbuf, ftype):
+async def skip(inbuf, ftype, budget=DEFAULT_MAX_DEPTH):
     if ftype == TType.BOOL or ftype == TType.BYTE:
         await inbuf.read(1)
 
@@ -219,22 +229,25 @@ async def skip(inbuf, ftype):
         await inbuf.read(unpack_i32(_size))
 
     elif ftype == TType.SET or ftype == TType.LIST:
+        check_depth(budget, " while skipping a Thrift container")
         v_type, sz = await read_list_begin(inbuf)
         for i in range(sz):
-            await skip(inbuf, v_type)
+            await skip(inbuf, v_type, budget - 1)
 
     elif ftype == TType.MAP:
+        check_depth(budget, " while skipping a Thrift container")
         k_type, v_type, sz = await read_map_begin(inbuf)
         for i in range(sz):
-            await skip(inbuf, k_type)
-            await skip(inbuf, v_type)
+            await skip(inbuf, k_type, budget - 1)
+            await skip(inbuf, v_type, budget - 1)
 
     elif ftype == TType.STRUCT:
+        check_depth(budget, " while skipping a Thrift struct")
         while True:
             f_type, fid = await read_field_begin(inbuf)
             if f_type == TType.STOP:
                 break
-            await skip(inbuf, f_type)
+            await skip(inbuf, f_type, budget - 1)
 
 
 class TAsyncBinaryProtocol(TAsyncProtocolBase):
@@ -242,15 +255,17 @@ class TAsyncBinaryProtocol(TAsyncProtocolBase):
 
     def __init__(self, trans,
                  strict_read=True, strict_write=True,
-                 decode_response=True, strict_decode=False):
+                 decode_response=True, strict_decode=False,
+                 max_depth=DEFAULT_MAX_DEPTH):
         TAsyncProtocolBase.__init__(self, trans)
         self.strict_read = strict_read
         self.strict_write = strict_write
         self.decode_response = decode_response
         self.strict_decode = strict_decode
+        self.max_depth = max_depth
 
     async def skip(self, ttype):
-        await skip(self.trans, ttype)
+        await skip(self.trans, ttype, self.max_depth)
 
     async def read_message_begin(self):
         api, ttype, seqid = await read_message_begin(
@@ -271,19 +286,21 @@ class TAsyncBinaryProtocol(TAsyncProtocolBase):
 
     async def read_struct(self, obj):
         return await read_struct(self.trans, obj, self.decode_response,
-                                 self.strict_decode)
+                                 self.strict_decode, self.max_depth)
 
     def write_struct(self, obj):
-        write_val(self.trans, TType.STRUCT, obj)
+        write_val(self.trans, TType.STRUCT, obj, budget=self.max_depth)
 
 
 class TAsyncBinaryProtocolFactory:
     def __init__(self, strict_read=True, strict_write=True,
-                 decode_response=True, strict_decode=False):
+                 decode_response=True, strict_decode=False,
+                 max_depth=DEFAULT_MAX_DEPTH):
         self.strict_read = strict_read
         self.strict_write = strict_write
         self.decode_response = decode_response
         self.strict_decode = strict_decode
+        self.max_depth = max_depth
 
     def get_protocol(self, trans):
         return TAsyncBinaryProtocol(
@@ -292,4 +309,5 @@ class TAsyncBinaryProtocolFactory:
             self.strict_write,
             self.decode_response,
             self.strict_decode,
+            self.max_depth,
         )

--- a/thriftpy2/protocol/binary.py
+++ b/thriftpy2/protocol/binary.py
@@ -13,6 +13,16 @@ VERSION_1 = -2147418112
 TYPE_MASK = 0x000000ff
 BIN_TYPES = (TType.STRING, TType.BINARY)
 
+# How deep structs and containers may nest, the outermost struct included,
+# before reading, writing or skipping raises RecursionError. Same default as
+# Apache Thrift and the Cython implementation.
+DEFAULT_MAX_DEPTH = 64
+
+
+def check_depth(budget, where):
+    if budget <= 0:
+        raise RecursionError("maximum nesting depth exceeded" + where)
+
 
 def pack_i8(byte):
     return struct.pack("!b", byte)
@@ -93,7 +103,8 @@ def write_map_begin(outbuf, ktype, vtype, size):
     outbuf.write(pack_i8(ktype) + pack_i8(vtype) + pack_i32(size))
 
 
-def write_val(outbuf, ttype, val, spec: Any = None):
+def write_val(outbuf, ttype, val, spec: Any = None,
+              budget=DEFAULT_MAX_DEPTH):
     if ttype == TType.BOOL:
         if val:
             outbuf.write(pack_i8(1))
@@ -128,10 +139,11 @@ def write_val(outbuf, ttype, val, spec: Any = None):
         else:
             e_type, t_spec = spec, None
 
+        check_depth(budget, " while writing a Thrift container")
         val_len = len(val)
         write_list_begin(outbuf, e_type, val_len)
         for e_val in val:
-            write_val(outbuf, e_type, e_val, t_spec)
+            write_val(outbuf, e_type, e_val, t_spec, budget - 1)
 
     elif ttype == TType.MAP:
         if isinstance(spec[0], int):
@@ -146,12 +158,14 @@ def write_val(outbuf, ttype, val, spec: Any = None):
         else:
             v_type, v_spec = spec[1]
 
+        check_depth(budget, " while writing a Thrift container")
         write_map_begin(outbuf, k_type, v_type, len(val))
         for k in iter(val):
-            write_val(outbuf, k_type, k, k_spec)
-            write_val(outbuf, v_type, val[k], v_spec)
+            write_val(outbuf, k_type, k, k_spec, budget - 1)
+            write_val(outbuf, v_type, val[k], v_spec, budget - 1)
 
     elif ttype == TType.STRUCT:
+        check_depth(budget, " while writing a Thrift struct")
         for fid in iter(val.thrift_spec):
             f_spec = val.thrift_spec[fid]
             if len(f_spec) == 3:
@@ -165,7 +179,7 @@ def write_val(outbuf, ttype, val, spec: Any = None):
                 continue
 
             write_field_begin(outbuf, f_type, fid)
-            write_val(outbuf, f_type, v, f_container_spec)
+            write_val(outbuf, f_type, v, f_container_spec, budget - 1)
         write_field_stop(outbuf)
 
 
@@ -215,7 +229,7 @@ def read_map_begin(inbuf):
 
 
 def read_val(inbuf, ttype, spec: Any = None, decode_response=True,
-             strict_decode=False):
+             strict_decode=False, budget=DEFAULT_MAX_DEPTH):
     if ttype == TType.BOOL:
         return bool(unpack_i8(inbuf.read(1)))
 
@@ -258,18 +272,20 @@ def read_val(inbuf, ttype, spec: Any = None, decode_response=True,
         else:
             v_type, v_spec = spec, None
 
+        check_depth(budget, " while reading a Thrift container")
+        budget -= 1
         result = []
         r_type, sz = read_list_begin(inbuf)
         # the v_type is useless here since we already get it from spec
         if (r_type != v_type
                 and not (r_type in BIN_TYPES and v_type in BIN_TYPES)):
             for _ in range(sz):
-                skip(inbuf, r_type)
+                skip(inbuf, r_type, budget)
             return []
 
         for i in range(sz):
             result.append(read_val(inbuf, v_type, v_spec, decode_response,
-                                   strict_decode))
+                                   strict_decode, budget))
         return result
 
     elif ttype == TType.MAP:
@@ -285,6 +301,8 @@ def read_val(inbuf, ttype, spec: Any = None, decode_response=True,
         else:
             v_type, v_spec = spec[1]
 
+        check_depth(budget, " while reading a Thrift container")
+        budget -= 1
         result = {}
         sk_type, sv_type, sz = read_map_begin(inbuf)
         if sk_type in BIN_TYPES:
@@ -293,33 +311,36 @@ def read_val(inbuf, ttype, spec: Any = None, decode_response=True,
             sv_type = v_type
         if sk_type != k_type or sv_type != v_type:
             for _ in range(sz):
-                skip(inbuf, sk_type)
-                skip(inbuf, sv_type)
+                skip(inbuf, sk_type, budget)
+                skip(inbuf, sv_type, budget)
             return {}
 
         for i in range(sz):
             k_val = read_val(inbuf, k_type, k_spec, decode_response,
-                             strict_decode)
+                             strict_decode, budget)
             v_val = read_val(inbuf, v_type, v_spec, decode_response,
-                             strict_decode)
+                             strict_decode, budget)
             result[k_val] = v_val
 
         return result
 
     elif ttype == TType.STRUCT:
         obj = spec()
-        read_struct(inbuf, obj, decode_response, strict_decode)
+        read_struct(inbuf, obj, decode_response, strict_decode, budget)
         return obj
 
 
-def read_struct(inbuf, obj, decode_response=True, strict_decode=False):
+def read_struct(inbuf, obj, decode_response=True, strict_decode=False,
+                budget=DEFAULT_MAX_DEPTH):
+    check_depth(budget, " while reading a Thrift struct")
+    budget -= 1
     while True:
         f_type, fid = read_field_begin(inbuf)
         if f_type == TType.STOP:
             break
 
         if fid not in obj.thrift_spec:
-            skip(inbuf, f_type)
+            skip(inbuf, f_type, budget)
             continue
 
         if len(obj.thrift_spec[fid]) == 3:
@@ -334,15 +355,15 @@ def read_struct(inbuf, obj, decode_response=True, strict_decode=False):
             if f_type in BIN_TYPES:
                 f_type = sf_type
             else:
-                skip(inbuf, f_type)
+                skip(inbuf, f_type, budget)
                 continue
 
         setattr(obj, f_name,
                 read_val(inbuf, f_type, f_container_spec, decode_response,
-                         strict_decode))
+                         strict_decode, budget))
 
 
-def skip(inbuf, ftype):
+def skip(inbuf, ftype, budget=DEFAULT_MAX_DEPTH):
     if ftype == TType.BOOL or ftype == TType.BYTE:
         inbuf.read(1)
 
@@ -362,22 +383,25 @@ def skip(inbuf, ftype):
         inbuf.read(unpack_i32(inbuf.read(4)))
 
     elif ftype == TType.SET or ftype == TType.LIST:
+        check_depth(budget, " while skipping a Thrift container")
         v_type, sz = read_list_begin(inbuf)
         for i in range(sz):
-            skip(inbuf, v_type)
+            skip(inbuf, v_type, budget - 1)
 
     elif ftype == TType.MAP:
+        check_depth(budget, " while skipping a Thrift container")
         k_type, v_type, sz = read_map_begin(inbuf)
         for i in range(sz):
-            skip(inbuf, k_type)
-            skip(inbuf, v_type)
+            skip(inbuf, k_type, budget - 1)
+            skip(inbuf, v_type, budget - 1)
 
     elif ftype == TType.STRUCT:
+        check_depth(budget, " while skipping a Thrift struct")
         while True:
             f_type, fid = read_field_begin(inbuf)
             if f_type == TType.STOP:
                 break
-            skip(inbuf, f_type)
+            skip(inbuf, f_type, budget - 1)
 
 
 class TBinaryProtocol(TProtocolBase):
@@ -385,15 +409,17 @@ class TBinaryProtocol(TProtocolBase):
 
     def __init__(self, trans,
                  strict_read=True, strict_write=True,
-                 decode_response=True, strict_decode=False):
+                 decode_response=True, strict_decode=False,
+                 max_depth=DEFAULT_MAX_DEPTH):
         TProtocolBase.__init__(self, trans)
         self.strict_read = strict_read
         self.strict_write = strict_write
         self.decode_response = decode_response
         self.strict_decode = strict_decode
+        self.max_depth = max_depth
 
     def skip(self, ttype):
-        skip(self.trans, ttype)
+        skip(self.trans, ttype, self.max_depth)
 
     def read_message_begin(self):
         api, ttype, seqid = read_message_begin(
@@ -412,21 +438,24 @@ class TBinaryProtocol(TProtocolBase):
 
     def read_struct(self, obj):
         return read_struct(self.trans, obj, self.decode_response,
-                           self.strict_decode)
+                           self.strict_decode, self.max_depth)
 
     def write_struct(self, obj):
-        write_val(self.trans, TType.STRUCT, obj)
+        write_val(self.trans, TType.STRUCT, obj, budget=self.max_depth)
 
 
 class TBinaryProtocolFactory:
     def __init__(self, strict_read=True, strict_write=True,
-                 decode_response=True, strict_decode=False):
+                 decode_response=True, strict_decode=False,
+                 max_depth=DEFAULT_MAX_DEPTH):
         self.strict_read = strict_read
         self.strict_write = strict_write
         self.decode_response = decode_response
         self.strict_decode = strict_decode
+        self.max_depth = max_depth
 
     def get_protocol(self, trans):
         return TBinaryProtocol(trans,
                                self.strict_read, self.strict_write,
-                               self.decode_response, self.strict_decode)
+                               self.decode_response, self.strict_decode,
+                               self.max_depth)

--- a/thriftpy2/protocol/cybin/cybin.pyx
+++ b/thriftpy2/protocol/cybin/cybin.pyx
@@ -10,6 +10,19 @@ from cpython cimport bool, PyObject_GetBuffer, PyBuffer_Release, PyBUF_ANY_CONTI
 from thriftpy2.thrift import TDecodeException
 from thriftpy2.transport.cybase cimport CyTransportBase, STACK_STRING_LEN
 
+# How deep structs and containers may nest, the outermost struct included,
+# before reading, writing or skipping raises RecursionError instead of
+# overflowing the native stack. Same default as Apache Thrift.
+DEFAULT_MAX_DEPTH = 64
+
+
+cdef inline int check_depth(int budget, const char *where) except -1:
+    if budget <= 0:
+        raise RecursionError(
+            "maximum nesting depth exceeded" + (<bytes>where).decode())
+    return 0
+
+
 cdef extern from "endian_port.h":
     int16_t htobe16(int16_t n)
     int32_t htobe32(int32_t n)
@@ -106,7 +119,7 @@ cdef inline int write_double(CyTransportBase buf, double val) except -1:
     return 0
 
 
-cdef inline write_list(CyTransportBase buf, object val, spec):
+cdef inline write_list(CyTransportBase buf, object val, spec, int budget):
     cdef TType e_type
     cdef int val_len
 
@@ -125,7 +138,7 @@ cdef inline write_list(CyTransportBase buf, object val, spec):
     write_i32(buf, val_len)
 
     for e_val in val:
-        c_write_val(buf, e_type, e_val, e_spec)
+        c_write_val(buf, e_type, e_val, e_spec, budget)
 
 
 cdef inline write_string(CyTransportBase buf, bytes val):
@@ -145,7 +158,7 @@ cdef inline write_buffer(CyTransportBase buf, val):
         PyBuffer_Release(&in_buffer)
 
 
-cdef inline write_dict(CyTransportBase buf, object val, spec):
+cdef inline write_dict(CyTransportBase buf, object val, spec, int budget):
     cdef int val_len
     cdef TType v_type, k_type
 
@@ -178,18 +191,20 @@ cdef inline write_dict(CyTransportBase buf, object val, spec):
     write_i32(buf, val_len)
 
     for k, v in val.items():
-        c_write_val(buf, k_type, k, k_spec)
-        c_write_val(buf, v_type, v, v_spec)
+        c_write_val(buf, k_type, k, k_spec, budget)
+        c_write_val(buf, v_type, v, v_spec, budget)
 
 
-cdef inline read_struct(CyTransportBase buf, obj, decode_response=True,
-                        strict_decode=False):
+cdef inline read_struct(CyTransportBase buf, obj, decode_response,
+                        strict_decode, int budget):
     cdef dict field_specs = obj.thrift_spec
     cdef int fid
     cdef TType field_type, ttype
     cdef tuple field_spec
     cdef str name
 
+    check_depth(budget, " while reading a Thrift struct")
+    budget -= 1
     while True:
         field_type = <TType>read_i08(buf)
         if field_type == T_STOP:
@@ -197,13 +212,13 @@ cdef inline read_struct(CyTransportBase buf, obj, decode_response=True,
 
         fid = read_i16(buf)
         if fid not in field_specs:
-            skip(buf, field_type)
+            c_skip(buf, field_type, budget)
             continue
 
         field_spec = field_specs[fid]
         ttype = field_spec[0]
         if field_type != ttype and not (ttype in BIN_TYPES and field_type in BIN_TYPES):
-            skip(buf, field_type)
+            c_skip(buf, field_type, budget)
             continue
 
         name = field_spec[1]
@@ -213,18 +228,20 @@ cdef inline read_struct(CyTransportBase buf, obj, decode_response=True,
             spec = field_spec[2]
 
         setattr(obj, name, c_read_val(buf, ttype, spec, decode_response,
-                                      strict_decode))
+                                      strict_decode, budget))
 
     return obj
 
 
-cdef inline write_struct(CyTransportBase buf, obj):
+cdef inline write_struct(CyTransportBase buf, obj, int budget):
     cdef int fid
     cdef TType f_type
     cdef dict thrift_spec = obj.thrift_spec
     cdef tuple field_spec
     cdef str f_name
 
+    check_depth(budget, " while writing a Thrift struct")
+    budget -= 1
     for fid, field_spec in thrift_spec.items():
         f_type = field_spec[0]
         f_name = field_spec[1]
@@ -242,7 +259,7 @@ cdef inline write_struct(CyTransportBase buf, obj):
             write_i08(buf, f_type)
         write_i16(buf, fid)
         try:
-            c_write_val(buf, f_type, v, container_spec)
+            c_write_val(buf, f_type, v, container_spec, budget)
         except (TypeError, AttributeError, AssertionError, OverflowError) as e:
             raise TDecodeException(obj.__class__.__name__, fid, f_name, v,
                                    f_type, container_spec)
@@ -279,7 +296,8 @@ cdef inline c_read_string(CyTransportBase buf, int32_t size,
 
 
 cdef c_read_val(CyTransportBase buf, TType ttype, spec=None,
-                decode_response=True, strict_decode=False):
+                decode_response=True, strict_decode=False,
+                int budget=DEFAULT_MAX_DEPTH):
     cdef int size
     cdef int64_t n
     cdef TType v_type, k_type, orig_type, orig_key_type
@@ -317,6 +335,8 @@ cdef c_read_val(CyTransportBase buf, TType ttype, spec=None,
             return c_read_binary(buf, size)
 
     elif ttype == T_SET or ttype == T_LIST:
+        check_depth(budget, " while reading a Thrift container")
+        budget -= 1
         if isinstance(spec, int):
             v_type = spec
             v_spec = None
@@ -329,13 +349,16 @@ cdef c_read_val(CyTransportBase buf, TType ttype, spec=None,
 
         if orig_type != v_type and not (orig_type in BIN_TYPES and v_type in BIN_TYPES):
             for _ in range(size):
-                skip(buf, orig_type)
+                c_skip(buf, orig_type, budget)
             return []
 
-        return [c_read_val(buf, v_type, v_spec, decode_response, strict_decode)
+        return [c_read_val(buf, v_type, v_spec, decode_response, strict_decode,
+                           budget)
                 for _ in range(size)]
 
     elif ttype == T_MAP:
+        check_depth(budget, " while reading a Thrift container")
+        budget -= 1
         key = spec[0]
         if isinstance(key, int):
             k_type = key
@@ -361,21 +384,24 @@ cdef c_read_val(CyTransportBase buf, TType ttype, spec=None,
             orig_type = v_type
         if orig_key_type != k_type or orig_type != v_type:
             for _ in range(size):
-                skip(buf, orig_key_type)
-                skip(buf, orig_type)
+                c_skip(buf, orig_key_type, budget)
+                c_skip(buf, orig_type, budget)
             return {}
 
         return {
-            c_read_val(buf, k_type, k_spec, decode_response, strict_decode):
-                c_read_val(buf, v_type, v_spec, decode_response, strict_decode)
+            c_read_val(buf, k_type, k_spec, decode_response, strict_decode,
+                       budget):
+                c_read_val(buf, v_type, v_spec, decode_response, strict_decode,
+                           budget)
             for _ in range(size)
         }
 
     elif ttype == T_STRUCT:
-        return read_struct(buf, spec(), decode_response, strict_decode)
+        return read_struct(buf, spec(), decode_response, strict_decode, budget)
 
 
-cdef c_write_val(CyTransportBase buf, TType ttype, val, spec=None):
+cdef c_write_val(CyTransportBase buf, TType ttype, val, spec=None,
+                 int budget=DEFAULT_MAX_DEPTH):
     if ttype == T_BOOL:
         write_i08(buf, 1 if val else 0)
 
@@ -408,16 +434,18 @@ cdef c_write_val(CyTransportBase buf, TType ttype, val, spec=None):
         write_string(buf, val)
 
     elif ttype == T_SET or ttype == T_LIST:
-        write_list(buf, val, spec)
+        check_depth(budget, " while writing a Thrift container")
+        write_list(buf, val, spec, budget - 1)
 
     elif ttype == T_MAP:
-        write_dict(buf, val, spec)
+        check_depth(budget, " while writing a Thrift container")
+        write_dict(buf, val, spec, budget - 1)
 
     elif ttype == T_STRUCT:
-        write_struct(buf, val)
+        write_struct(buf, val, budget)
 
 
-cpdef skip(CyTransportBase buf, TType ttype):
+cdef int c_skip(CyTransportBase buf, TType ttype, int budget) except -1:
     cdef TType v_type, k_type, f_type
     cdef int size
 
@@ -433,33 +461,45 @@ cpdef skip(CyTransportBase buf, TType ttype):
         size = read_i32(buf)
         c_read_binary(buf, size)
     elif ttype == T_SET or ttype == T_LIST:
+        check_depth(budget, " while skipping a Thrift container")
+        budget -= 1
         v_type = <TType>read_i08(buf)
         size = read_i32(buf)
         for _ in range(size):
-            skip(buf, v_type)
+            c_skip(buf, v_type, budget)
     elif ttype == T_MAP:
+        check_depth(budget, " while skipping a Thrift container")
+        budget -= 1
         k_type = <TType>read_i08(buf)
         v_type = <TType>read_i08(buf)
         size = read_i32(buf)
         for _ in range(size):
-            skip(buf, k_type)
-            skip(buf, v_type)
+            c_skip(buf, k_type, budget)
+            c_skip(buf, v_type, budget)
     elif ttype == T_STRUCT:
+        check_depth(budget, " while skipping a Thrift struct")
+        budget -= 1
         while 1:
             f_type = <TType>read_i08(buf)
             if f_type == T_STOP:
                 break
             read_i16(buf)
-            skip(buf, f_type)
+            c_skip(buf, f_type, budget)
+    return 0
+
+
+def skip(CyTransportBase buf, TType ttype):
+    c_skip(buf, ttype, DEFAULT_MAX_DEPTH)
 
 
 def read_val(CyTransportBase buf, TType ttype, decode_response=True,
              strict_decode=False):
-    return c_read_val(buf, ttype, None, decode_response, strict_decode)
+    return c_read_val(buf, ttype, None, decode_response, strict_decode,
+                      DEFAULT_MAX_DEPTH)
 
 
 def write_val(CyTransportBase buf, TType ttype, val, spec=None):
-    c_write_val(buf, ttype, val, spec)
+    c_write_val(buf, ttype, val, spec, DEFAULT_MAX_DEPTH)
 
 
 cdef class TCyBinaryProtocol(object):
@@ -468,17 +508,20 @@ cdef class TCyBinaryProtocol(object):
     cdef public bool strict_write
     cdef public bool decode_response
     cdef public bool strict_decode
+    cdef public int max_depth
 
     def __init__(self, trans, strict_read=True, strict_write=True,
-                 decode_response=True, strict_decode=False):
+                 decode_response=True, strict_decode=False,
+                 max_depth=DEFAULT_MAX_DEPTH):
         self.trans = trans
         self.strict_read = strict_read
         self.strict_write = strict_write
         self.decode_response = decode_response
         self.strict_decode = strict_decode
+        self.max_depth = max_depth
 
     def skip(self, ttype):
-        skip(self.trans, <TType>(ttype))
+        c_skip(self.trans, <TType>(ttype), self.max_depth)
 
     def read_message_begin(self):
         cdef int32_t size, version, seqid
@@ -523,14 +566,14 @@ cdef class TCyBinaryProtocol(object):
     def read_struct(self, obj):
         try:
             return read_struct(self.trans, obj, self.decode_response,
-                               self.strict_decode)
+                               self.strict_decode, self.max_depth)
         except Exception:
             self.trans.clean()
             raise
 
     def write_struct(self, obj):
         try:
-            write_struct(self.trans, obj)
+            write_struct(self.trans, obj, self.max_depth)
         except Exception:
             self.trans.clean()
             raise
@@ -538,13 +581,15 @@ cdef class TCyBinaryProtocol(object):
 
 class TCyBinaryProtocolFactory(object):
     def __init__(self, strict_read=True, strict_write=True,
-                 decode_response=True, strict_decode=False):
+                 decode_response=True, strict_decode=False,
+                 max_depth=DEFAULT_MAX_DEPTH):
         self.strict_read = strict_read
         self.strict_write = strict_write
         self.decode_response = decode_response
         self.strict_decode = strict_decode
+        self.max_depth = max_depth
 
     def get_protocol(self, trans):
         return TCyBinaryProtocol(
             trans, self.strict_read, self.strict_write, self.decode_response,
-            self.strict_decode)
+            self.strict_decode, self.max_depth)


### PR DESCRIPTION
Add a nesting depth guard to the Cython binary protocol so deeply nested structs raise `RecursionError` instead of crashing the process with SIGSEGV. The limit is a fixed budget (default 64, matching Apache Thrift) rather than the interpreter recursion limit, since that one counts Python frames and says nothing about the native stack; `max_depth` on the protocol and factory adjusts it. The pure Python and asyncio `TBinaryProtocol` get the same parameter and counting, so every binary implementation accepts and rejects the same payloads. Fixes #394 and #395.