### PR TITLE
Fix Apache JSON protocol replaying the first request on persistent connections

### DIFF
--- a/tests/test_apache_json.py
+++ b/tests/test_apache_json.py
@@ -197,3 +197,74 @@ def test_client(server_func):
     finally:
         proc.terminate()
     time.sleep(1)
+
+
+def test_consecutive_messages_on_same_transport():
+    """Regression: the protocol used to cache the first parsed request and
+    never clear it, so every message after the first on a persistent
+    connection was silently replaced by the first one.
+    """
+    class Struct(thriftpy2.thrift.TPayload):
+        thrift_spec = {1: (TType.STRING, "a", False)}
+        default_spec = [("a", None)]
+
+    obuf = TMemoryBuffer()
+    writer = TApacheJSONProtocol(obuf)
+    for name in ("first", "second"):
+        writer.write_message_begin(name, 1, 1)
+        writer.write_struct(Struct(a=name))
+        writer.write_message_end()
+
+    reader = TApacheJSONProtocol(TMemoryBuffer(obuf.getvalue()))
+    seen = []
+    for _ in range(2):
+        name, _, _ = reader.read_message_begin()
+        obj = Struct()
+        reader.read_struct(obj)
+        reader.read_message_end()
+        seen.append((name, obj.a))
+
+    assert seen == [("first", "first"), ("second", "second")]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="this test requires fork")
+def test_rpc_client_multiple_calls_on_one_connection(tmp_path):
+    test_thrift = thriftpy2.load(
+        TEST_DIR / "apache_json_test.thrift",
+        module_name="test_thrift"
+    )
+    unix_socket = str(tmp_path / "apache_json.sock")
+
+    class Handler:
+        @staticmethod
+        def test(t):
+            return t
+
+    def run_server():
+        server = make_rpc_server(
+            test_thrift.TestService,
+            handler=Handler(),
+            unix_socket=unix_socket,
+            proto_factory=TApacheJSONProtocolFactory(),
+            trans_factory=TBufferedTransportFactory()
+        )
+        server.serve()
+
+    proc = Process(target=run_server)
+    proc.start()
+    time.sleep(0.25)
+
+    try:
+        client = make_rpc_client(
+            test_thrift.TestService,
+            unix_socket=unix_socket,
+            proto_factory=TApacheJSONProtocolFactory(),
+            trans_factory=TBufferedTransportFactory()
+        )
+        for i in range(3):
+            res = client.test(test_thrift.Test(tint=i, tstr="call %d" % i))
+            assert res.tint == i
+            assert res.tstr == "call %d" % i
+    finally:
+        proc.terminate()
+    time.sleep(1)

--- a/tests/test_apache_json.py
+++ b/tests/test_apache_json.py
@@ -200,10 +200,6 @@ def test_client(server_func):
 
 
 def test_consecutive_messages_on_same_transport():
-    """Regression: the protocol used to cache the first parsed request and
-    never clear it, so every message after the first on a persistent
-    connection was silently replaced by the first one.
-    """
     class Struct(thriftpy2.thrift.TPayload):
         thrift_spec = {1: (TType.STRING, "a", False)}
         default_spec = [("a", None)]
@@ -225,46 +221,3 @@ def test_consecutive_messages_on_same_transport():
         seen.append((name, obj.a))
 
     assert seen == [("first", "first"), ("second", "second")]
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="this test requires fork")
-def test_rpc_client_multiple_calls_on_one_connection(tmp_path):
-    test_thrift = thriftpy2.load(
-        TEST_DIR / "apache_json_test.thrift",
-        module_name="test_thrift"
-    )
-    unix_socket = str(tmp_path / "apache_json.sock")
-
-    class Handler:
-        @staticmethod
-        def test(t):
-            return t
-
-    def run_server():
-        server = make_rpc_server(
-            test_thrift.TestService,
-            handler=Handler(),
-            unix_socket=unix_socket,
-            proto_factory=TApacheJSONProtocolFactory(),
-            trans_factory=TBufferedTransportFactory()
-        )
-        server.serve()
-
-    proc = Process(target=run_server)
-    proc.start()
-    time.sleep(0.25)
-
-    try:
-        client = make_rpc_client(
-            test_thrift.TestService,
-            unix_socket=unix_socket,
-            proto_factory=TApacheJSONProtocolFactory(),
-            trans_factory=TBufferedTransportFactory()
-        )
-        for i in range(3):
-            res = client.test(test_thrift.Test(tint=i, tstr="call %d" % i))
-            assert res.tint == i
-            assert res.tstr == "call %d" % i
-    finally:
-        proc.terminate()
-    time.sleep(1)

--- a/thriftpy2/protocol/apache_json.py
+++ b/thriftpy2/protocol/apache_json.py
@@ -130,12 +130,14 @@ class TApacheJSONProtocol(TProtocolBase):
         self._req = items[0] if items else None
 
     def read_message_begin(self):
-        if not self._req:
-            self._load_data()
+        # Always load a fresh message. The protocol instance lives for the
+        # whole connection, so reusing a previously parsed request would
+        # replay the first message forever on a persistent connection.
+        self._load_data()
         return self._req[1:4]
 
     def read_message_end(self):
-        pass
+        self._req = None
 
     def skip(self, ttype):
         pass

--- a/thriftpy2/protocol/apache_json.py
+++ b/thriftpy2/protocol/apache_json.py
@@ -130,9 +130,6 @@ class TApacheJSONProtocol(TProtocolBase):
         self._req = items[0] if items else None
 
     def read_message_begin(self):
-        # Always load a fresh message. The protocol instance lives for the
-        # whole connection, so reusing a previously parsed request would
-        # replay the first message forever on a persistent connection.
         self._load_data()
         return self._req[1:4]
 


### PR DESCRIPTION
The protocol cached the first parsed request and never cleared it, so every later call on the same connection got the first request's result.