### PR TITLE
Skip mismatched field types in the pure Python binary protocol

### DIFF
--- a/tests/test_aio_protocol_binary.py
+++ b/tests/test_aio_protocol_binary.py
@@ -154,3 +154,26 @@ async def test_max_depth_is_configurable():
     obj = TTree()
     await p.read_struct(obj)
     assert tree_depth(obj) == depth
+
+
+class TStringThenInt(TPayload):
+    thrift_spec = {
+        1: (TType.STRING, "a", False),
+        2: (TType.I32, "b", False),
+    }
+    default_spec = [("a", None), ("b", None)]
+
+
+class TIntThenInt(TPayload):
+    thrift_spec = {
+        1: (TType.I32, "a", False),
+        2: (TType.I32, "b", False),
+    }
+    default_spec = [("a", None), ("b", None)]
+
+
+@pytest.mark.asyncio
+async def test_read_struct_skips_field_with_mismatched_type():
+    blob = encode(TStringThenInt(a="hello", b=7))
+    obj = await decode(blob, TIntThenInt)
+    assert obj == TIntThenInt(a=None, b=7)

--- a/tests/test_protocol_binary.py
+++ b/tests/test_protocol_binary.py
@@ -402,3 +402,28 @@ def test_max_depth_is_configurable():
     obj = TTree()
     p.read_struct(obj)
     assert tree_depth(obj) == depth
+
+
+class TStringThenInt(TPayload):
+    thrift_spec = {
+        1: (TType.STRING, "a", False),
+        2: (TType.I32, "b", False),
+    }
+    default_spec = [("a", None), ("b", None)]
+
+
+class TIntThenInt(TPayload):
+    thrift_spec = {
+        1: (TType.I32, "a", False),
+        2: (TType.I32, "b", False),
+    }
+    default_spec = [("a", None), ("b", None)]
+
+
+def test_read_struct_skips_field_with_mismatched_type():
+    b = BytesIO()
+    proto.TBinaryProtocol(b).write_struct(TStringThenInt(a="hello", b=7))
+    b.seek(0)
+    obj = TIntThenInt()
+    proto.TBinaryProtocol(b).read_struct(obj)
+    assert obj == TIntThenInt(a=None, b=7)

--- a/thriftpy2/contrib/aio/protocol/binary.py
+++ b/thriftpy2/contrib/aio/protocol/binary.py
@@ -193,10 +193,10 @@ async def read_struct(inbuf, obj, decode_response=True, strict_decode=False,
         else:
             sf_type, f_name, f_container_spec, f_req = obj.thrift_spec[fid]
 
-        # it really should equal here. but since we already wasted
-        # space storing the duplicate info, let's check it.
+        # STRING and BINARY are interchangeable on the wire, anything else
+        # that does not match the spec is skipped.
         if f_type != sf_type:
-            if f_type in BIN_TYPES:
+            if f_type in BIN_TYPES and sf_type in BIN_TYPES:
                 f_type = sf_type
             else:
                 await skip(inbuf, f_type, budget)

--- a/thriftpy2/protocol/binary.py
+++ b/thriftpy2/protocol/binary.py
@@ -349,10 +349,10 @@ def read_struct(inbuf, obj, decode_response=True, strict_decode=False,
         else:
             sf_type, f_name, f_container_spec, f_req = obj.thrift_spec[fid]
 
-        # it really should equal here. but since we already wasted
-        # space storing the duplicate info, let's check it.
+        # STRING and BINARY are interchangeable on the wire, anything else
+        # that does not match the spec is skipped.
         if f_type != sf_type:
-            if f_type in BIN_TYPES:
+            if f_type in BIN_TYPES and sf_type in BIN_TYPES:
                 f_type = sf_type
             else:
                 skip(inbuf, f_type, budget)


### PR DESCRIPTION
The pure Python binary protocol (sync and asyncio) read a STRING/BINARY field as whatever type the spec declared instead of skipping it, so a string on the wire where an i32 was expected corrupted every following field, while cybin already got this right.