### PR TITLE
Fix map key and value type mismatch detection

### DIFF
--- a/tests/test_aio_protocol_binary.py
+++ b/tests/test_aio_protocol_binary.py
@@ -177,3 +177,26 @@ async def test_read_struct_skips_field_with_mismatched_type():
     blob = encode(TStringThenInt(a="hello", b=7))
     obj = await decode(blob, TIntThenInt)
     assert obj == TIntThenInt(a=None, b=7)
+
+
+class TStringKeyMap(TPayload):
+    thrift_spec = {
+        1: (TType.MAP, "m", (TType.STRING, TType.I32), False),
+        2: (TType.I32, "x", False),
+    }
+    default_spec = [("m", None), ("x", None)]
+
+
+class TIntKeyMap(TPayload):
+    thrift_spec = {
+        1: (TType.MAP, "m", (TType.I32, TType.I32), False),
+        2: (TType.I32, "x", False),
+    }
+    default_spec = [("m", None), ("x", None)]
+
+
+@pytest.mark.asyncio
+async def test_read_struct_skips_map_with_mismatched_key_type():
+    blob = encode(TStringKeyMap(m={"abcd": 1, "efgh": 2}, x=5))
+    obj = await decode(blob, TIntKeyMap)
+    assert obj == TIntKeyMap(m={}, x=5)

--- a/tests/test_aio_protocol_compact.py
+++ b/tests/test_aio_protocol_compact.py
@@ -4,7 +4,7 @@ import pytest
 
 from thriftpy2.thrift import TType, TPayload
 from thriftpy2.contrib.aio.protocol import compact
-from test_aio_protocol_binary import AsyncBytesIO
+from test_aio_protocol_binary import AsyncBytesIO, TIntKeyMap, TStringKeyMap
 
 
 class TItem(TPayload):
@@ -29,3 +29,14 @@ async def test_strict_decode():
 
     with pytest.raises(UnicodeDecodeError):
         await proto._read_val(TType.STRING)
+
+
+@pytest.mark.asyncio
+async def test_read_struct_skips_map_with_mismatched_key_type():
+    b = BytesIO()
+    compact.TAsyncCompactProtocol(b).write_struct(
+        TStringKeyMap(m={"abcd": 1, "efgh": 2}, x=5))
+    _, proto = gen_proto(b.getvalue())
+    obj = TIntKeyMap()
+    await proto.read_struct(obj)
+    assert obj == TIntKeyMap(m={}, x=5)

--- a/tests/test_type_mismatch.py
+++ b/tests/test_type_mismatch.py
@@ -1,9 +1,10 @@
-from unittest import TestCase
+from unittest import TestCase, expectedFailure
 
 from thriftpy2.thrift import TType, TPayload
 
 from thriftpy2.transport.memory import TMemoryBuffer
 from thriftpy2.protocol.binary import TBinaryProtocol
+from thriftpy2.protocol.compact import TCompactProtocol
 
 from thriftpy2._compat import CYTHON
 
@@ -72,6 +73,33 @@ class MismatchTestCase(TestCase):
 
         assert item2.addr == {}
 
+    def test_map_type_mismatch_with_string_on_wire(self):
+        class TWireItem(TPayload):
+            thrift_spec = {
+                1: (TType.MAP, "addr", (TType.STRING, TType.I32), False),
+                2: (TType.I32, "x", False),
+            }
+            default_spec = [("addr", None), ("x", None)]
+
+        class TMismatchItem(TPayload):
+            thrift_spec = {
+                1: (TType.MAP, "addr", (TType.I32, TType.I32), False),
+                2: (TType.I32, "x", False),
+            }
+            default_spec = [("addr", None), ("x", None)]
+
+        t = self.BUFFER()
+        p = self.PROTO(t)
+
+        p.write_struct(TWireItem(addr={"abcd": 1, "efgh": 2}, x=5))
+        p.write_message_end()
+
+        item2 = TMismatchItem()
+        p.read_struct(item2)
+
+        assert item2.addr == {}
+        assert item2.x == 5
+
     def test_struct_mismatch(self):
         class MismatchStruct(TPayload):
             thrift_spec = {
@@ -103,6 +131,15 @@ class MismatchTestCase(TestCase):
 
         assert len(item2.data) == 3
         assert all([i.b for i in item2.data])
+
+
+class CompactMismatchTestCase(MismatchTestCase):
+    PROTO = TCompactProtocol
+
+    # The compact protocol does not check list element types yet.
+    @expectedFailure
+    def test_list_type_mismatch(self):
+        super().test_list_type_mismatch()
 
 
 if CYTHON:

--- a/thriftpy2/contrib/aio/protocol/binary.py
+++ b/thriftpy2/contrib/aio/protocol/binary.py
@@ -149,11 +149,11 @@ async def read_val(inbuf, ttype, spec: Any = None, decode_response=True,
         budget -= 1
         result = {}
         sk_type, sv_type, sz = await read_map_begin(inbuf)
-        if sk_type in BIN_TYPES:
-            sk_type = k_type
-        if sv_type in BIN_TYPES:
-            sv_type = v_type
-        if sk_type != k_type or sv_type != v_type:
+        k_mismatch = sk_type != k_type and not (
+            sk_type in BIN_TYPES and k_type in BIN_TYPES)
+        v_mismatch = sv_type != v_type and not (
+            sv_type in BIN_TYPES and v_type in BIN_TYPES)
+        if k_mismatch or v_mismatch:
             for _ in range(sz):
                 await skip(inbuf, sk_type, budget)
                 await skip(inbuf, sv_type, budget)

--- a/thriftpy2/contrib/aio/protocol/compact.py
+++ b/thriftpy2/contrib/aio/protocol/compact.py
@@ -231,7 +231,11 @@ class TAsyncCompactProtocol(TCompactProtocol,  # Inherit all of the writing
 
             result = {}
             sk_type, sv_type, sz = await self._read_map_begin()
-            if sk_type != k_type or sv_type != v_type:
+            k_mismatch = sk_type != k_type and not (
+                sk_type in BIN_TYPES and k_type in BIN_TYPES)
+            v_mismatch = sv_type != v_type and not (
+                sv_type in BIN_TYPES and v_type in BIN_TYPES)
+            if k_mismatch or v_mismatch:
                 for _ in range(sz):
                     await self.skip(sk_type)
                     await self.skip(sv_type)

--- a/thriftpy2/protocol/binary.py
+++ b/thriftpy2/protocol/binary.py
@@ -305,11 +305,11 @@ def read_val(inbuf, ttype, spec: Any = None, decode_response=True,
         budget -= 1
         result = {}
         sk_type, sv_type, sz = read_map_begin(inbuf)
-        if sk_type in BIN_TYPES:
-            sk_type = k_type
-        if sv_type in BIN_TYPES:
-            sv_type = v_type
-        if sk_type != k_type or sv_type != v_type:
+        k_mismatch = sk_type != k_type and not (
+            sk_type in BIN_TYPES and k_type in BIN_TYPES)
+        v_mismatch = sv_type != v_type and not (
+            sv_type in BIN_TYPES and v_type in BIN_TYPES)
+        if k_mismatch or v_mismatch:
             for _ in range(sz):
                 skip(inbuf, sk_type, budget)
                 skip(inbuf, sv_type, budget)

--- a/thriftpy2/protocol/compact.py
+++ b/thriftpy2/protocol/compact.py
@@ -325,11 +325,11 @@ class TCompactProtocol(TProtocolBase):
 
             result = {}
             sk_type, sv_type, sz = self._read_map_begin()
-            if sk_type in BIN_TYPES:
-                sk_type = k_type
-            if sv_type in BIN_TYPES:
-                sv_type = v_type
-            if sk_type != k_type or sv_type != v_type:
+            k_mismatch = sk_type != k_type and not (
+                sk_type in BIN_TYPES and k_type in BIN_TYPES)
+            v_mismatch = sv_type != v_type and not (
+                sv_type in BIN_TYPES and v_type in BIN_TYPES)
+            if k_mismatch or v_mismatch:
                 for _ in range(sz):
                     self.skip(sk_type)
                     self.skip(sv_type)

--- a/thriftpy2/protocol/cybin/cybin.pyx
+++ b/thriftpy2/protocol/cybin/cybin.pyx
@@ -378,11 +378,11 @@ cdef c_read_val(CyTransportBase buf, TType ttype, spec=None,
         orig_key_type = <TType>read_i08(buf)
         orig_type = <TType>read_i08(buf)
         size = read_i32(buf)
-        if orig_key_type in BIN_TYPES:
-            orig_key_type = k_type
-        if orig_type in BIN_TYPES:
-            orig_type = v_type
-        if orig_key_type != k_type or orig_type != v_type:
+        k_mismatch = orig_key_type != k_type and not (
+            orig_key_type in BIN_TYPES and k_type in BIN_TYPES)
+        v_mismatch = orig_type != v_type and not (
+            orig_type in BIN_TYPES and v_type in BIN_TYPES)
+        if k_mismatch or v_mismatch:
             for _ in range(size):
                 c_skip(buf, orig_key_type, budget)
                 c_skip(buf, orig_type, budget)


### PR DESCRIPTION
When reading a map, the binary, cybin and compact protocols replaced a STRING or BINARY wire type with whatever the spec declared before comparing them, so a string-keyed map read with an i32 key spec was decoded as garbage and corrupted every following field instead of being skipped.