### PR TITLE
Skip lists and sets with mismatched element types in the compact protocol

### DIFF
--- a/tests/test_aio_protocol_compact.py
+++ b/tests/test_aio_protocol_compact.py
@@ -40,3 +40,28 @@ async def test_read_struct_skips_map_with_mismatched_key_type():
     obj = TIntKeyMap()
     await proto.read_struct(obj)
     assert obj == TIntKeyMap(m={}, x=5)
+
+
+@pytest.mark.asyncio
+async def test_read_struct_skips_list_with_mismatched_element_type():
+    class TIntList(TPayload):
+        thrift_spec = {
+            1: (TType.LIST, "l", TType.I32, False),
+            2: (TType.I32, "x", False),
+        }
+        default_spec = [("l", None), ("x", None)]
+
+    class TStringList(TPayload):
+        thrift_spec = {
+            1: (TType.LIST, "l", TType.STRING, False),
+            2: (TType.I32, "x", False),
+        }
+        default_spec = [("l", None), ("x", None)]
+
+    b = BytesIO()
+    compact.TAsyncCompactProtocol(b).write_struct(
+        TStringList(l=["ab", "cd"], x=99))
+    _, proto = gen_proto(b.getvalue())
+    obj = TIntList()
+    await proto.read_struct(obj)
+    assert obj == TIntList(l=[], x=99)

--- a/tests/test_type_mismatch.py
+++ b/tests/test_type_mismatch.py
@@ -1,4 +1,4 @@
-from unittest import TestCase, expectedFailure
+from unittest import TestCase
 
 from thriftpy2.thrift import TType, TPayload
 
@@ -135,11 +135,6 @@ class MismatchTestCase(TestCase):
 
 class CompactMismatchTestCase(MismatchTestCase):
     PROTO = TCompactProtocol
-
-    # The compact protocol does not check list element types yet.
-    @expectedFailure
-    def test_list_type_mismatch(self):
-        super().test_list_type_mismatch()
 
 
 if CYTHON:

--- a/thriftpy2/contrib/aio/protocol/compact.py
+++ b/thriftpy2/contrib/aio/protocol/compact.py
@@ -209,6 +209,12 @@ class TAsyncCompactProtocol(TCompactProtocol,  # Inherit all of the writing
                 v_type, v_spec = spec, None
             result = []
             r_type, sz = await self._read_collection_begin()
+            if r_type != v_type and not (
+                    r_type in BIN_TYPES and v_type in BIN_TYPES):
+                for _ in range(sz):
+                    await self.skip(r_type)
+                self._read_collection_end()
+                return []
 
             for i in range(sz):
                 result.append(await self._read_val(v_type, v_spec))

--- a/thriftpy2/protocol/compact.py
+++ b/thriftpy2/protocol/compact.py
@@ -303,6 +303,12 @@ class TCompactProtocol(TProtocolBase):
                 v_type, v_spec = spec, None
             result = []
             r_type, sz = self._read_collection_begin()
+            if r_type != v_type and not (
+                    r_type in BIN_TYPES and v_type in BIN_TYPES):
+                for _ in range(sz):
+                    self.skip(r_type)
+                self._read_collection_end()
+                return []
 
             for i in range(sz):
                 result.append(self._read_val(v_type, v_spec))


### PR DESCRIPTION
Compact now matches binary and skips containers whose wire element type differs from the spec.